### PR TITLE
Implement dynamic strategy retrieval and execution

### DIFF
--- a/src/app/components/strategy-calculation/strategy-calculation.component.ts
+++ b/src/app/components/strategy-calculation/strategy-calculation.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import {FormsModule} from '@angular/forms';
 import {JsonPipe, NgForOf, NgIf} from '@angular/common';
@@ -16,8 +16,8 @@ import {TradingDataService} from '../../services/trading-data.service';
   standalone: true,
   styleUrls: ['./strategy-calculation.component.css']
 })
-export class StrategyCalculationComponent {
-  strategies: string[] = ['Stratégie 1', 'Stratégie 2', 'Stratégie 3', 'Trend Following']; // Tu peux les charger dynamiquement si besoin
+export class StrategyCalculationComponent implements OnInit {
+  strategies: string[] = [];
   symbols: string[] = ['ES', 'NQ', 'YM', 'EURUSD', 'BTCUSDT']; // Exemples de symboles
   comparedSymbol: string[] = ['ES', 'NQ', 'YM', 'EURUSD', 'BTCUSDT']; // Exemples de symboles
   timeframes: string[] = ['1min', '5min', '15min', '1h'];
@@ -32,12 +32,32 @@ export class StrategyCalculationComponent {
 
   constructor(private http: HttpClient, private tradingService: TradingDataService) {}
 
+  ngOnInit(): void {
+    this.tradingService.listStrategies().subscribe({
+      next: (names) => {
+        this.strategies = names;
+      },
+      error: (err) => {
+        console.error('Erreur lors du chargement des stratégies :', err);
+      }
+    });
+  }
+
   calculateStrategy() {
     if (!this.selectedStrategy || !this.selectedSymbol || !this.selectedTimeframe || !this.startDate || !this.endDate || !this.selectedComparedSymbol) {
       alert('Tous les champs sont requis pour lancer le calcul !');
       return;
     }
-    this.result = this.tradingService.getCalculationStrategy(this.selectedStrategy,this.selectedSymbol, this.selectedComparedSymbol, this.selectedTimeframe,this.startDate,this.endDate).subscribe({
+    this.result = this.tradingService
+      .getCalculationStrategy(
+        this.selectedStrategy,
+        this.selectedSymbol,
+        this.selectedComparedSymbol,
+        this.selectedTimeframe,
+        this.startDate,
+        this.endDate
+      )
+      .subscribe({
       next: (response) => {
         console.log('Résultat de la stratégie', response);
         this.result = response;

--- a/src/app/services/trading-data.service.ts
+++ b/src/app/services/trading-data.service.ts
@@ -44,17 +44,33 @@ export class TradingDataService {
     const url = `${this.apiUrl}/all-strategies`;
     return this.http.get<any>(url);
   }
+
+  listStrategies(): Observable<string[]> {
+    const url = `${this.apiUrl}/strategies`;
+    return this.http.get<string[]>(url);
+  }
   getLiveCandle(symbol: string, timeframe: string) {
     // Remplace par ton vrai endpoint en live si t'en as un !
     const url = `${this.apiUrl}/api/live-candle?symbol=${symbol}&timeframe=${timeframe}`;
     return this.http.get<any>(url);
   }
-  getCalculationStrategy(selectedStrategy: string, selectedSymbol: string, selectedComparedSymbol: string, selectedTimeframe: string, startDate: string, endDate: string){
+  getCalculationStrategy(strategyName: string,
+                         symbol: string,
+                         comparedSymbol: string,
+                         timeframe: string,
+                         startDate: string,
+                         endDate: string,
+                         period: number = 1000) {
     const encodedStartDate = encodeURIComponent(startDate);
     const encodedEndDate = encodeURIComponent(endDate);
 
-    //const url = `http://localhost:8094/strategies/calculate?strategy=${this.selectedStrategy}&symbol=${this.selectedSymbol}&startDate=${encodedStartDate}&endDate=${encodedEndDate}`;
-    const url = `http://localhost:8090/trend-following?timeframe=${selectedTimeframe}&symbol=${selectedSymbol}&startDate=${encodedStartDate}&endDate=${encodedEndDate}&comparedSymbol=${selectedComparedSymbol}`;
+    let url = `${this.apiUrl}/run-strategy-by-name?strategyName=${strategyName}&symbol=${symbol}&timeframe=${timeframe}&period=${period}`;
+
+    if (comparedSymbol) {
+      url += `&comparedSymbol=${comparedSymbol}`;
+    }
+
+    url += `&startDate=${encodedStartDate}&endDate=${encodedEndDate}`;
 
     return this.http.get(url);
   }


### PR DESCRIPTION
## Summary
- dynamically fetch available strategies from backend
- update calculation endpoint to run strategies by name

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869724aac748323973fcb97d49d8cee