### PR TITLE
Add typed models and update services

### DIFF
--- a/src/app/components/historical-data/historical-data.component.ts
+++ b/src/app/components/historical-data/historical-data.component.ts
@@ -3,6 +3,7 @@ import { NgChartsModule } from 'ng2-charts';
 import { CommonModule } from '@angular/common';
 import { Chart, registerables} from 'chart.js';
 import { TradingDataService } from '../../services/trading-data.service';
+import { Candle } from '../../models/candle';
 import 'chartjs-chart-financial'; // ✅ Importe le plugin pour les chandeliers
 import 'chartjs-adapter-date-fns'; // ✅ Pour gérer les dates correctement
 import zoomPlugin from 'chartjs-plugin-zoom';
@@ -21,7 +22,7 @@ import { format } from 'date-fns';
 })
 export class HistoricalDataComponent implements AfterViewInit {
   chart: any;
-  candles: any[] = [];
+  candles: Candle[] = [];
   trades = [
     {
       entryDate: new Date('2024-02-08T14:15:00'),
@@ -63,7 +64,9 @@ export class HistoricalDataComponent implements AfterViewInit {
   }
 
   ngAfterViewInit() {
-    this.tradingService.getHistoricalCandlesTimeframeCME('EURUSD', 'M5', this.startDate, this.endDate).subscribe(data => {
+    this.tradingService
+      .getHistoricalCandlesTimeframeCME('EURUSD', 'M5', this.startDate, this.endDate)
+      .subscribe((data: Candle[]) => {
       console.log('Données reçues :', data); // ✅ Vérifie que les données arrivent bien
       console.log(Chart.getChart('candlestickChart')); // ✅ Devrait afficher `undefined` (normal)
       console.log(Chart.registry.controllers);
@@ -78,7 +81,14 @@ export class HistoricalDataComponent implements AfterViewInit {
   }
 
   loadData() {
-    this.tradingService.getHistoricalCandlesTimeframeCME(this.selectedSymbol, this.selectedTimeframe, this.startDate, this.endDate).subscribe(data => {
+    this.tradingService
+      .getHistoricalCandlesTimeframeCME(
+        this.selectedSymbol,
+        this.selectedTimeframe,
+        this.startDate,
+        this.endDate
+      )
+      .subscribe((data: Candle[]) => {
       console.log('Données reçues loadData :', data);
       this.candles = data;
       //console.log("Données utilisées :", this.candles.map(c => new Date(c.date).toUTCString()));

--- a/src/app/components/live-data/live-data.component.ts
+++ b/src/app/components/live-data/live-data.component.ts
@@ -3,6 +3,7 @@ import { NgChartsModule } from 'ng2-charts';
 import { CommonModule } from '@angular/common';
 import { Chart, registerables } from 'chart.js';
 import { TradingDataService } from '../../services/trading-data.service';
+import { Candle } from '../../models/candle';
 import 'chartjs-chart-financial';
 import 'chartjs-adapter-date-fns';
 import zoomPlugin from 'chartjs-plugin-zoom';
@@ -19,7 +20,7 @@ import { FormsModule } from '@angular/forms';
 export class LiveDataComponent implements AfterViewInit, OnDestroy {
 
   chart: any;
-  candles: any[] = [];
+  candles: Candle[] = [];
 
   symbols = ['EURUSD', 'GBPUSD', 'USDJPY', 'NASDAQ', 'SP500'];
   timeframes = ['M1', 'M5', 'M15', 'M30', 'H1', 'H4', 'D1'];
@@ -128,8 +129,9 @@ export class LiveDataComponent implements AfterViewInit, OnDestroy {
 
   fetchLiveCandle() {
     // Appelle ton service pour récupérer la dernière bougie en live
-    this.tradingService.getLiveCandle(this.selectedSymbol, this.selectedTimeframe)
-      .subscribe(latestCandle => {
+    this.tradingService
+      .getLiveCandle(this.selectedSymbol, this.selectedTimeframe)
+      .subscribe((latestCandle: Candle) => {
 
         // ➡️ Si déjà une candle pour ce timestamp, on la met à jour
         const lastCandle = this.candles[this.candles.length - 1];

--- a/src/app/components/screen-strategies/screen-strategies.component.ts
+++ b/src/app/components/screen-strategies/screen-strategies.component.ts
@@ -3,6 +3,7 @@ import {FormsModule} from '@angular/forms';
 import {DatePipe, DecimalPipe, NgForOf, NgIf, PercentPipe} from '@angular/common';
 import {Router} from '@angular/router';
 import {TradingDataService} from '../../services/trading-data.service';
+import { Strategy } from '../../models/strategy';
 import {Chart} from 'chart.js';
 
 @Component({
@@ -22,36 +23,14 @@ export class ScreenStrategiesComponent implements OnInit {
 
   symbols: string[] = []; // À remplir via une API si besoin
   selectedSymbol: string = '';
-  strategies: {
-    runId?: string,
-    name: string,
-    symbol?: string,
-    startDate?: Date,
-    endDate?: Date,
-    winningTrades?: number,
-    losingTrades?: number,
-    winRate?: number,
-    lossRate?: number,
-    totalReturn?: number,
-    maxDrawdown?: number,
-    averageRR?: number,
-    averageTrade?: number,
-    tradeCount?: number
-    averageTP?: number,
-    averageSL?: number,
-    comparedSymbol?: string
-    totalNetReturn?: number,
-    netWinCount?: number,
-    netLossCount?: number,
-    averageNetTrade?: number
-  }[] = [];
+  strategies: Strategy[] = [];
   isLoading: boolean = false;
 
   constructor(private router: Router, private tradingService: TradingDataService
     // private strategyService: StrategyService (à injecter pour le backend)
   ) { }
 
-  goToDetails(strategy: any) {
+  goToDetails(strategy: Strategy) {
     console.log('GO vers', strategy);
     this.router.navigate(
       ['/strategy-detail', strategy.name, strategy.runId, strategy.symbol, strategy.comparedSymbol],
@@ -99,7 +78,7 @@ export class ScreenStrategiesComponent implements OnInit {
     ];
 
     this.tradingService.getAllCalculatedStrategies().subscribe({
-      next: (backendData: any[]) => {
+      next: (backendData: Strategy[]) => {
         const formattedBackends = Array.isArray(backendData) ? backendData : [backendData];
         console.log(formattedBackends);
         const mapped = formattedBackends.map(s => {

--- a/src/app/components/strategy-detail/strategy-detail.component.ts
+++ b/src/app/components/strategy-detail/strategy-detail.component.ts
@@ -4,6 +4,8 @@ import {DatePipe, NgIf} from '@angular/common';
 import { CommonModule } from '@angular/common';
 import { TradingDataService } from '../../services/trading-data.service';
 import {TradeCandlestickChartComponent} from '../trade-candlestick-chart/trade-candlestick-chart.component';
+import { Strategy } from '../../models/strategy';
+import { Trade } from '../../models/trade';
 
 @Component({
   selector: 'app-strategy-detail',
@@ -19,8 +21,8 @@ import {TradeCandlestickChartComponent} from '../trade-candlestick-chart/trade-c
 })
 export class StrategyDetailComponent implements OnInit {
 
-  strategy: any;
-  trades: any[] = [];
+  strategy: Strategy | null = null;
+  trades: Trade[] = [];
   currentTradeIndex: number = 0;
   comparedSymbol: string = '';
   symbol: string = '';
@@ -89,8 +91,8 @@ export class StrategyDetailComponent implements OnInit {
     } else {
       this.strategy = { name: strategyName, symbol: this.symbol, comparedSymbol: this.comparedSymbol };
     }
-    this.tradingDataService.getTradesByStrategyName(strategyName!,runId!).subscribe({
-      next: (trades: any[] | null | undefined) => {
+    this.tradingDataService.getTradesByStrategyName(strategyName!, runId!).subscribe({
+      next: (trades: Trade[] | null | undefined) => {
         console.log("Avant le map",trades);
         const formattedTrades = Array.isArray(trades) ? trades.map(t => ({
           id: t.id,
@@ -118,7 +120,7 @@ export class StrategyDetailComponent implements OnInit {
     });
 
   }
-  getMockTrades(): any[] {
+  getMockTrades(): Trade[] {
     return [
       {
         id: 1,
@@ -161,7 +163,7 @@ export class StrategyDetailComponent implements OnInit {
     const diffMs = Math.abs(endDate.getTime() - startDate.getTime());
     return Math.floor(diffMs / (1000 * 60));
   }
-  get currentTrade() {
+  get currentTrade(): Trade {
     return this.trades[this.currentTradeIndex];
   }
 

--- a/src/app/components/trade-candlestick-chart/trade-candlestick-chart.component.ts
+++ b/src/app/components/trade-candlestick-chart/trade-candlestick-chart.component.ts
@@ -8,6 +8,8 @@ import {
   CandlestickController,
   CandlestickElement
 } from 'chartjs-chart-financial';
+import { Candle } from '../../models/candle';
+import { Trade } from '../../models/trade';
 
 @Component({
   selector: 'app-trade-candlestick-chart',
@@ -37,13 +39,14 @@ export class TradeCandlestickChartComponent implements OnChanges {
   }
 
   loadData(): void {
-    this.tradingService.getCandlesForTrade(this.tradeId, this.timeframe, this.symbol, this.comparedSymbol, 50, 50).subscribe(response => {
-      const { candles, trade, comparedCandles } = response as any;
+    this.tradingService
+      .getCandlesForTrade(this.tradeId, this.timeframe, this.symbol, this.comparedSymbol, 50, 50)
+      .subscribe(({ candles, trade, comparedCandles }: { candles: Candle[]; comparedCandles: Candle[]; trade: Trade }) => {
 
       // 🛡️ Validation des données
       const data = candles
-        .filter((c: any) => !isNaN(new Date(c.date).getTime()))
-        .map((c: any) => ({
+        .filter(c => !isNaN(new Date(c.date).getTime()))
+        .map(c => ({
           x: new Date(c.date).getTime(),
           o: c.open,
           h: c.high,
@@ -52,8 +55,8 @@ export class TradeCandlestickChartComponent implements OnChanges {
         }));
 
       const comparedData = (comparedCandles || [])
-        .filter((c: any) => !isNaN(new Date(c.date).getTime()))
-        .map((c: any) => ({
+        .filter(c => !isNaN(new Date(c.date).getTime()))
+        .map(c => ({
           x: new Date(c.date).getTime(),
           o: c.open,
           h: c.high,
@@ -86,7 +89,7 @@ export class TradeCandlestickChartComponent implements OnChanges {
     });
   }
 
-  renderChart(data: any[], trade: any, canvasId: string, annotate: boolean): void {
+  renderChart(data: any[], trade: Trade, canvasId: string, annotate: boolean): void {
     const canvas = document.getElementById(canvasId) as HTMLCanvasElement;
     const ctx = canvas?.getContext('2d');
     if (!data?.length || !trade || !canvas || !ctx) {

--- a/src/app/models/candle.ts
+++ b/src/app/models/candle.ts
@@ -1,0 +1,8 @@
+export interface Candle {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume?: number;
+}

--- a/src/app/models/strategy.ts
+++ b/src/app/models/strategy.ts
@@ -1,0 +1,23 @@
+export interface Strategy {
+  runId?: string;
+  name: string;
+  symbol?: string;
+  comparedSymbol?: string;
+  startDate?: Date;
+  endDate?: Date;
+  winningTrades?: number;
+  losingTrades?: number;
+  winRate?: number;
+  lossRate?: number;
+  totalReturn?: number;
+  maxDrawdown?: number;
+  averageRR?: number;
+  averageTrade?: number;
+  tradeCount?: number;
+  averageTP?: number;
+  averageSL?: number;
+  totalNetReturn?: number;
+  netWinCount?: number;
+  netLossCount?: number;
+  averageNetTrade?: number;
+}

--- a/src/app/models/trade.ts
+++ b/src/app/models/trade.ts
@@ -1,0 +1,12 @@
+export interface Trade {
+  id?: number;
+  tradeType?: string;
+  entryTimestamp: string;
+  exitTimestamp: string;
+  entryPrice: number;
+  exitPrice: number;
+  stopLoss?: number;
+  takeProfit?: number;
+  strategyName?: string;
+  result?: string;
+}

--- a/src/app/services/trading-data.service.ts
+++ b/src/app/services/trading-data.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { Candle } from '../models/candle';
+import { Trade } from '../models/trade';
+import { Strategy } from '../models/strategy';
 
 @Injectable({
   providedIn: 'root'
@@ -10,49 +13,69 @@ export class TradingDataService {
 
   constructor(private http: HttpClient) {}
 
-  getCandlesForTrade(tradeId: number, timeframe: string, symbol: string, comparedSymbol: string, beforeCandles: number = 50, afterCandles: number = 50) {
-    return this.http.get<{ candles: any[], comparedCandles: any[], trade: any }>(`${this.apiUrl}/api/finance/charts/from-trade?tradeId=${tradeId}&timeframe=${timeframe}&symbol=${symbol}&comparedSymbol=${comparedSymbol}&beforeCandles=${beforeCandles}&afterCandles=${afterCandles}`);
+  getCandlesForTrade(
+    tradeId: number,
+    timeframe: string,
+    symbol: string,
+    comparedSymbol: string,
+    beforeCandles: number = 50,
+    afterCandles: number = 50
+  ): Observable<{ candles: Candle[]; comparedCandles: Candle[]; trade: Trade }> {
+    return this.http.get<{ candles: Candle[]; comparedCandles: Candle[]; trade: Trade }>(
+      `${this.apiUrl}/api/finance/charts/from-trade?tradeId=${tradeId}&timeframe=${timeframe}&symbol=${symbol}&comparedSymbol=${comparedSymbol}&beforeCandles=${beforeCandles}&afterCandles=${afterCandles}`
+    );
   }
-  getTradesByStrategyName(strategyName: string, runId: string): Observable<any[]> {
-    console.log("runId "+runId);
-    console.log("Strategy Name "+strategyName);
+
+  getTradesByStrategyName(strategyName: string, runId: string): Observable<Trade[]> {
+    console.log('runId ' + runId);
+    console.log('Strategy Name ' + strategyName);
     const url = `${this.apiUrl}/get-trades-strategy?strategyName=${strategyName}&runId=${runId}`;
-    return this.http.get<any[]>(url);
+    return this.http.get<Trade[]>(url);
   }
-  getHistoricalCandles(symbol: string, timeframe: string): Observable<any> {
-    return this.http.get(`${this.apiUrl}/api/finance/charts/candles?symbol=${symbol}&timeframe=${timeframe}`);
+  getHistoricalCandles(symbol: string, timeframe: string): Observable<Candle[]> {
+    return this.http.get<Candle[]>(`${this.apiUrl}/api/finance/charts/candles?symbol=${symbol}&timeframe=${timeframe}`);
   }
   // http://localhost:8092/rollover-volume/unified-candles?startDate=2010-06-10T00:00:00&endDate=2010-06-15T00:00:00
-  getHistoricalCandlesCME(symbol: string, timeframe: string, startDate: string, endDate: string): Observable<any> {
+  getHistoricalCandlesCME(
+    symbol: string,
+    timeframe: string,
+    startDate: string,
+    endDate: string
+  ): Observable<Candle[]> {
     const encodedStartDate = encodeURIComponent(startDate);
     const encodedEndDate = encodeURIComponent(endDate);
 
     const url = `${this.apiUrl}/rollover-volume/unified-candles?symbol=${symbol}&timeframe=${timeframe}&startDate=${encodedStartDate}&endDate=${encodedEndDate}`;
 
-    return this.http.get(url);
+    return this.http.get<Candle[]>(url);
   }
 
-  getHistoricalCandlesTimeframeCME(symbol: string, timeframe: string, startDate: string, endDate: string): Observable<any> {
+  getHistoricalCandlesTimeframeCME(
+    symbol: string,
+    timeframe: string,
+    startDate: string,
+    endDate: string
+  ): Observable<Candle[]> {
     const encodedStartDate = encodeURIComponent(startDate);
     const encodedEndDate = encodeURIComponent(endDate);
 
     const url = `${this.apiUrl}/api/finance/charts/candles/date-time?symbol=${symbol}&timeframe=${timeframe}&startDate=${encodedStartDate}&endDate=${encodedEndDate}`;
 
-    return this.http.get(url);
+    return this.http.get<Candle[]>(url);
   }
-  getAllCalculatedStrategies(){
+  getAllCalculatedStrategies(): Observable<Strategy[]> {
     const url = `${this.apiUrl}/all-strategies`;
-    return this.http.get<any>(url);
+    return this.http.get<Strategy[]>(url);
   }
 
   listStrategies(): Observable<string[]> {
     const url = `${this.apiUrl}/all-name-strategies`;
     return this.http.get<string[]>(url);
   }
-  getLiveCandle(symbol: string, timeframe: string) {
+  getLiveCandle(symbol: string, timeframe: string): Observable<Candle> {
     // Remplace par ton vrai endpoint en live si t'en as un !
     const url = `${this.apiUrl}/api/live-candle?symbol=${symbol}&timeframe=${timeframe}`;
-    return this.http.get<any>(url);
+    return this.http.get<Candle>(url);
   }
   getCalculationStrategy(strategyName: string,
                          symbol: string,


### PR DESCRIPTION
## Summary
- define `Candle`, `Trade` and `Strategy` interfaces
- return typed observables in `TradingDataService`
- update components to consume the new types

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a71cc1e648323af0337ec9f65120f