### PR TITLE
feat: add isolated signals lab

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,6 +12,10 @@ export const routes: Routes = [
   { path: 'strategy-calculation', component: StrategyCalculationComponent },
   { path: 'screen-strategies', component: ScreenStrategiesComponent },
   { path: 'strategy-detail/:name/:runId/:symbol/:comparedSymbol', component: StrategyDetailComponent },
-  { path: 'live-data', component: LiveDataComponent }
+  { path: 'live-data', component: LiveDataComponent },
+  {
+    path: '_lab/signals',
+    loadChildren: () => import('./labs/signals/signals.routes').then(m => m.SIGNALS_ROUTES)
+  }
   //{ path: '', redirectTo: '/historical-data', pathMatch: 'full' } // Redirection par défaut
 ];

--- a/src/app/labs/signals/README.md
+++ b/src/app/labs/signals/README.md
@@ -1,0 +1,9 @@
+# Signals Lab (Isolated)
+
+Path: `/_lab/signals`
+
+This is a fully isolated Angular Signals demo: counter with persistence via `effect`, and a todo list with `signal` + `computed`.
+
+## Run
+- `ng serve`
+- Open http://localhost:4200/_lab/signals

--- a/src/app/labs/signals/signals.routes.ts
+++ b/src/app/labs/signals/signals.routes.ts
@@ -1,0 +1,6 @@
+import { Routes } from '@angular/router';
+import { SignalsHomePage } from './ui/signals-home.page';
+
+export const SIGNALS_ROUTES: Routes = [
+  { path: '', component: SignalsHomePage, title: 'Signals Lab' },
+];

--- a/src/app/labs/signals/state/signals.store.spec.ts
+++ b/src/app/labs/signals/state/signals.store.spec.ts
@@ -1,0 +1,33 @@
+import { SignalsStore } from './signals.store';
+
+describe('SignalsStore', () => {
+  let store: SignalsStore;
+  beforeEach(() => { store = new SignalsStore(); });
+
+  it('increments/decrements/resets count', () => {
+    expect(store.count()).toBe(0);
+    store.inc();
+    expect(store.count()).toBe(1);
+    store.dec();
+    expect(store.count()).toBe(0);
+    store.reset();
+    expect(store.count()).toBe(0);
+  });
+
+  it('manages todos', () => {
+    store.addTodo('A');
+    store.addTodo('B');
+    const ids = store.todos().map(t => t.id);
+    expect(store.todos().length).toBe(2);
+
+    store.toggleTodo(ids[0]);
+    expect(store.completedCount()).toBe(1);
+    expect(store.activeCount()).toBe(1);
+
+    store.removeTodo(ids[1]);
+    expect(store.todos().length).toBe(1);
+
+    store.clearCompleted();
+    expect(store.todos().length).toBe(0);
+  });
+});

--- a/src/app/labs/signals/state/signals.store.ts
+++ b/src/app/labs/signals/state/signals.store.ts
@@ -1,0 +1,73 @@
+import { Injectable, computed, effect, signal } from '@angular/core';
+
+export type Todo = { id: string; title: string; completed: boolean };
+export type Filter = 'all' | 'active' | 'completed';
+
+function uid() { return Math.random().toString(36).slice(2, 9); }
+
+@Injectable({ providedIn: 'root' })
+export class SignalsStore {
+  // Counter
+  readonly count = signal<number>(0);
+
+  // Counter derived status
+  readonly countLabel = computed(() => {
+    const c = this.count();
+    if (c < 5) return 'Low';
+    if (c < 10) return 'Medium';
+    return 'High';
+  });
+
+  // Persist to localStorage
+  private readonly persistEffect = effect(onCleanup => {
+    const key = 'signals-demo:count';
+    // load once
+    const stored = localStorage.getItem(key);
+    if (stored !== null) {
+      const parsed = Number(stored);
+      if (!Number.isNaN(parsed)) this.count.set(parsed);
+    }
+    const unsub = effect(() => {
+      localStorage.setItem(key, String(this.count()));
+    });
+    onCleanup(() => unsub.destroy());
+  });
+
+  inc() { this.count.update(c => c + 1); }
+  dec() { this.count.update(c => c - 1); }
+  reset() { this.count.set(0); }
+
+  // Todos
+  readonly todos = signal<readonly Todo[]>([]);
+  readonly filter = signal<Filter>('all');
+
+  readonly activeCount = computed(() => this.todos().filter(t => !t.completed).length);
+  readonly completedCount = computed(() => this.todos().filter(t => t.completed).length);
+  readonly filteredTodos = computed(() => {
+    const f = this.filter();
+    const items = this.todos();
+    switch (f) {
+      case 'active': return items.filter(t => !t.completed);
+      case 'completed': return items.filter(t => t.completed);
+      default: return items;
+    }
+  });
+
+  addTodo(title: string) {
+    const t: Todo = { id: uid(), title: title.trim(), completed: false };
+    if (!t.title) return;
+    this.todos.update(list => [t, ...list]);
+  }
+
+  toggleTodo(id: string) {
+    this.todos.update(list => list.map(t => t.id === id ? { ...t, completed: !t.completed } : t));
+  }
+
+  removeTodo(id: string) {
+    this.todos.update(list => list.filter(t => t.id !== id));
+  }
+
+  clearCompleted() {
+    this.todos.update(list => list.filter(t => !t.completed));
+  }
+}

--- a/src/app/labs/signals/ui/signals-home.page.ts
+++ b/src/app/labs/signals/ui/signals-home.page.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CounterCard } from './widgets/counter.card';
+import { TodoCard } from './widgets/todo.card';
+
+@Component({
+  selector: 'app-signals-home',
+  standalone: true,
+  imports: [CommonModule, CounterCard, TodoCard],
+  template: `
+    <section class="container">
+      <h1>Signals Lab</h1>
+      <p class="subtitle">Demo of <strong>signal</strong>, <strong>computed</strong> and <strong>effect</strong>.</p>
+      <div class="grid">
+        <counter-card />
+        <todo-card />
+      </div>
+    </section>
+  `,
+  styles: [`
+    .container{padding:1rem;max-width:1000px;margin:0 auto}
+    .subtitle{opacity:.7}
+    .grid{display:grid;gap:1rem}
+    @media(min-width:900px){.grid{grid-template-columns:1fr 1fr}}
+  `]
+})
+export class SignalsHomePage {}

--- a/src/app/labs/signals/ui/widgets/counter.card.ts
+++ b/src/app/labs/signals/ui/widgets/counter.card.ts
@@ -1,0 +1,33 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SignalsStore } from '../../state/signals.store';
+
+@Component({
+  selector: 'counter-card',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <article class="card">
+      <header><h2>Counter (Signals)</h2></header>
+      <div class="value">{{ store.count() }}</div>
+      <div class="label">Status: {{ store.countLabel() }}</div>
+      <div class="row">
+        <button (click)="store.dec()">−</button>
+        <button (click)="store.reset()">Reset</button>
+        <button (click)="store.inc()">+</button>
+      </div>
+      <p class="hint">Value persists via <code>effect</code> → <code>localStorage</code>.</p>
+    </article>
+  `,
+  styles: [`
+    .card{border:1px solid #e1e1e1;border-radius:12px;padding:1rem}
+    .row{display:flex;gap:.5rem;margin-top:.5rem}
+    button{padding:.4rem .8rem;border-radius:8px;border:1px solid #ccc;background:#fafafa;cursor:pointer}
+    .value{font-size:2.2rem;font-weight:700}
+    .label{opacity:.8}
+    .hint{opacity:.6;font-size:.9rem}
+  `]
+})
+export class CounterCard {
+  protected readonly store = inject(SignalsStore);
+}

--- a/src/app/labs/signals/ui/widgets/todo.card.ts
+++ b/src/app/labs/signals/ui/widgets/todo.card.ts
@@ -1,0 +1,61 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { SignalsStore, Filter } from '../../state/signals.store';
+
+@Component({
+  selector: 'todo-card',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <article class="card">
+      <header><h2>Todos (Signals)</h2></header>
+
+      <form (ngSubmit)="add()" class="row">
+        <input type="text" [(ngModel)]="title" name="title" placeholder="Add todo…" />
+        <button type="submit">Add</button>
+      </form>
+
+      <nav class="filters">
+        <button [class.active]="store.filter()==='all'" (click)="setFilter('all')">All</button>
+        <button [class.active]="store.filter()==='active'" (click)="setFilter('active')">Active</button>
+        <button [class.active]="store.filter()==='completed'" (click)="setFilter('completed')">Completed</button>
+      </nav>
+
+      <ul class="todos">
+        <li *ngFor="let t of store.filteredTodos()">
+          <label>
+            <input type="checkbox" [checked]="t.completed" (change)="store.toggleTodo(t.id)" />
+            <span [class.done]="t.completed">{{ t.title }}</span>
+          </label>
+          <button class="danger" (click)="store.removeTodo(t.id)">×</button>
+        </li>
+      </ul>
+
+      <footer class="stats">
+        <span>Active: {{ store.activeCount() }}</span>
+        <span>Completed: {{ store.completedCount() }}</span>
+        <button (click)="store.clearCompleted()" [disabled]="store.completedCount()===0">Clear completed</button>
+      </footer>
+    </article>
+  `,
+  styles: [`
+    .card{border:1px solid #e1e1e1;border-radius:12px;padding:1rem}
+    form.row{display:flex;gap:.5rem}
+    input[type=text]{flex:1;padding:.5rem;border-radius:8px;border:1px solid #ccc}
+    button{padding:.4rem .8rem;border-radius:8px;border:1px solid #ccc;background:#fafafa;cursor:pointer}
+    .filters{display:flex;gap:.5rem;margin:.5rem 0}
+    .filters .active{font-weight:700}
+    ul.todos{list-style:none;padding:0;margin:.5rem 0;display:flex;flex-direction:column;gap:.25rem}
+    li{display:flex;align-items:center;justify-content:space-between;border-bottom:1px dashed #eee;padding:.25rem 0}
+    .done{opacity:.7;text-decoration:line-through}
+    .danger{border-color:#e99;background:#fee}
+    .stats{display:flex;gap:1rem;align-items:center;justify-content:space-between;margin-top:.5rem}
+  `]
+})
+export class TodoCard {
+  protected readonly store = inject(SignalsStore);
+  protected title = '';
+  add(){ this.store.addTodo(this.title); this.title=''; }
+  setFilter(f: Filter){ this.store.filter.set(f); }
+}


### PR DESCRIPTION
## Summary
- add a lazy-loaded Signals lab route at /_lab/signals
- implement standalone counter and todo widgets driven by a signal-based store
- cover store behaviors with unit tests and add local README documentation

## Testing
- `npm run test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a5627f748323b4be9a3fd98c7777