### PR TITLE
Add generated architecture and feature documentation

### DIFF
--- a/ARCHITECTURE_MAP.md
+++ b/ARCHITECTURE_MAP.md
@@ -1,0 +1,49 @@
+# Architecture Map
+
+## Modules
+| Nom | Chemin | Rôle | Dépendances majeures |
+| --- | --- | --- | --- |
+| _(aucun module NgModule)_ | — | L'application s'appuie sur des composants standalone et `bootstrapApplication`. | — |
+
+## Composants & Vues
+| Nom | Chemin | Rôle bref | Dépendances majeures |
+| --- | --- | --- | --- |
+| AppComponent | src/app/app.component.ts | Shell racine affichant le router outlet et les liens principaux. | `@angular/router` (RouterOutlet, RouterLink) |
+| HistoricalDataComponent | src/app/components/historical-data/historical-data.component.ts | Affiche des bougies historiques avec annotations et filtres de période. | TradingDataService, Chart.js (`chartjs-chart-financial`, zoom, annotation), ng2-charts, FormsModule |
+| LiveDataComponent | src/app/components/live-data/live-data.component.ts | Stream de bougies en direct avec démarrage/arrêt et zoom. | TradingDataService, Chart.js financial + zoom, FormsModule |
+| ScreenStrategiesComponent | src/app/components/screen-strategies/screen-strategies.component.ts | Liste des stratégies calculées avec métriques et navigation vers le détail. | TradingDataService, Angular router, Angular pipes (Date, Decimal, Percent) |
+| StatisticDataComponent | src/app/components/statistic-data/statistic-data.component.ts | Charge des analyses statistiques (bullish/bearish, entropie…) et les visualise en bar chart. | HttpClient, Chart.js (via NgChartsModule), FormsModule |
+| StrategyCalculationComponent | src/app/components/strategy-calculation/strategy-calculation.component.ts | Formulaire pour lancer des calculs de stratégie et afficher le JSON de résultat. | TradingDataService, HttpClient, FormsModule |
+| StrategyDetailComponent | src/app/components/strategy-detail/strategy-detail.component.ts | Résumé d'une stratégie, navigation dans les trades, affichage graphique par trade. | TradingDataService, Router, TradeCandlestickChartComponent |
+| TradeCandlestickChartComponent | src/app/components/trade-candlestick-chart/trade-candlestick-chart.component.ts | Graphiques candlestick principal/comparé pour un trade donné avec annotations. | TradingDataService, Chart.js financial, zoom, annotation |
+| SignalsHomePage | src/app/labs/signals/ui/signals-home.page.ts | Page laboratoire démontrant les signaux Angular (counter & todo). | CounterCard, TodoCard |
+| CounterCard | src/app/labs/signals/ui/widgets/counter.card.ts | Carte compteur utilisant les signaux pour un état persistant. | SignalsStore |
+| TodoCard | src/app/labs/signals/ui/widgets/todo.card.ts | Carte todo avec filtres basée sur les signaux Angular. | SignalsStore, FormsModule |
+
+## Services / Stores / Utilitaires
+| Nom | Chemin | Rôle bref | Dépendances |
+| --- | --- | --- | --- |
+| TradingDataService | src/app/services/trading-data.service.ts | Accès HTTP aux données de trading (bougies, stratégies, statistiques, live). | HttpClient, `environment.apiUrl` |
+| SignalsStore | src/app/labs/signals/state/signals.store.ts | Store Angular Signals pour la démo counter/todos avec persistance locale. | Angular signals API (`signal`, `computed`, `effect`), localStorage |
+
+## Guards & Interceptors
+Aucun guard (`*.guard.ts`) ni interceptor (`*.interceptor.ts`) détecté dans le projet.
+
+## Routing
+| Chemin | Composant/Module | Lazy ? | Guards |
+| --- | --- | --- | --- |
+| `historical-data` | HistoricalDataComponent | Non | — |
+| `statistics` | StatisticDataComponent | Non | — |
+| `strategy-calculation` | StrategyCalculationComponent | Non | — |
+| `screen-strategies` | ScreenStrategiesComponent | Non | — |
+| `strategy-detail/:name/:runId/:symbol/:comparedSymbol` | StrategyDetailComponent | Non | — |
+| `live-data` | LiveDataComponent | Non | — |
+| `_lab/signals` | `SIGNALS_ROUTES` (SignalsHomePage) | Oui (`loadChildren`) | — |
+
+## State Management
+| Store | Type | Sélecteurs / Computed | Effets |
+| --- | --- | --- | --- |
+| SignalsStore | Angular Signals store (`providedIn: 'root'`) | `count`, `countLabel`, `todos`, `filter`, `activeCount`, `completedCount`, `filteredTodos` | Persistance `effect` vers `localStorage`, effets internes de mise à jour |
+
+## Modèles & DTO
+Aucun fichier `*.model.ts` ou définition de DTO détecté — informations `unknown` à ce stade.

--- a/FEATURE_CATALOG.md
+++ b/FEATURE_CATALOG.md
@@ -1,0 +1,29 @@
+# Feature Catalog
+
+## Pages & vues principales
+| Route | Description | Composants clés | Données affichées |
+| --- | --- | --- | --- |
+| `/historical-data` | Tableau de bord pour charger et visualiser des chandeliers historiques avec annotations de trades. | `HistoricalDataComponent` | Bougies OHLC filtrées par symbole/timeframe, zones d'entrée/sortie mockées, options zoom/pan. |
+| `/live-data` | Suivi en direct des bougies avec démarrage/arrêt du flux. | `LiveDataComponent` | Bougies live rafraîchies via polling, statut du stream. |
+| `/statistics` | Console d'analyses statistiques multi-timeframes. | `StatisticDataComponent` | Résultats JSON transformés en tableau + bar chart pour statistiques bullish/bearish, entropie, cycles, etc. |
+| `/strategy-calculation` | Formulaire pour lancer le calcul d'une stratégie paramétrée. | `StrategyCalculationComponent` | Résultat JSON d'exécution de stratégie, listes déroulantes de symboles/timeframes. |
+| `/screen-strategies` | Listing de stratégies calculées avec métriques et navigation détail. | `ScreenStrategiesComponent` | Table (mock + API) avec runId, winrate, drawdown, moyennes RR/TP/SL, comparaisons de symboles. |
+| `/strategy-detail/:name/:runId/:symbol/:comparedSymbol` | Vue détaillée d'une stratégie avec navigation trade par trade. | `StrategyDetailComponent`, `TradeCandlestickChartComponent` | Résumé stratégie, table de métriques, graphique candlestick du trade sélectionné + symbole comparé, liste des trades. |
+| `/_lab/signals` | Laboratoire démontrant Angular Signals (counter, todo). | `SignalsHomePage`, `CounterCard`, `TodoCard` | Compteur persistant, liste de todos filtrable (données locales). |
+
+## Graphiques & visualisations
+| Composant | Librairie | Source de données | Options avancées |
+| --- | --- | --- | --- |
+| HistoricalDataComponent | Chart.js 4 (`chartjs-chart-financial`, `chartjs-plugin-zoom`, `chartjs-plugin-annotation`) via `ng2-charts` | `TradingDataService.getHistoricalCandlesTimeframeCME` (bougies OHLC) | Zoom et pan sur l'axe X, annotations de trades via boxes colorées, formatage temporel `date-fns`. |
+| LiveDataComponent | Chart.js 4 financial + zoom | `TradingDataService.getLiveCandle` (polling) | Mise à jour incrémentale du dataset, zoom/pan horizontal. |
+| StatisticDataComponent | Chart.js bar | Endpoints `filter/*` (statistiques) | Multiple datasets par timeframe, rafraîchissement à chaque chargement. |
+| TradeCandlestickChartComponent | Chart.js 4 financial + zoom + annotation | `TradingDataService.getCandlesForTrade` (bougies principales & comparées) | Annotations box pour la période de trade, double graphique (trade vs symbole comparé), parsing désactivé pour performance. |
+
+## UX & Performance
+- Standalone components et `bootstrapApplication` pour réduire la configuration `NgModule`.
+- `provideZoneChangeDetection({ eventCoalescing: true })` dans `app.config.ts` pour limiter la fréquence des changements de zone.
+- Lazy-loading du laboratoire `_lab/signals` via `loadChildren`.
+- Plugins Chart.js activent zoom/pan pour l'exploration utilisateur.
+- Persistance locale du compteur Signals via `effect` + `localStorage` (UX démo).
+- Aucune stratégie de change detection personnalisée détectée (comportement par défaut).
+- Pas de virtual scroll identifié.

--- a/INTEGRATIONS_ROADMAP.md
+++ b/INTEGRATIONS_ROADMAP.md
@@ -1,0 +1,35 @@
+# Integrations & Roadmap
+
+## Intégrations actuelles (HTTP)
+| Méthode | Endpoint (relatif à `environment.apiUrl`) | Payload / Query | Usage |
+| --- | --- | --- | --- |
+| GET | `/api/finance/charts/from-trade` | `tradeId`, `timeframe`, `symbol`, `comparedSymbol`, `beforeCandles`, `afterCandles` | Charger les bougies d'un trade et d'un symbole comparé. |
+| GET | `/get-trades-strategy` | `strategyName`, `runId` | Récupérer les trades d'une stratégie. |
+| GET | `/api/finance/charts/candles` | `symbol`, `timeframe` | Bougies historiques simples. |
+| GET | `/rollover-volume/unified-candles` | `symbol`, `timeframe`, `startDate`, `endDate` | Bougies CME selon plage donnée. |
+| GET | `/api/finance/charts/candles/date-time` | `symbol`, `timeframe`, `startDate`, `endDate` | Bougies filtrées par dates pour chargement historique. |
+| GET | `/all-strategies` | — | Listing complet des stratégies calculées. |
+| GET | `/all-name-strategies` | — | Liste des noms de stratégies disponibles. |
+| GET | `/api/live-candle` | `symbol`, `timeframe` | Bougie live la plus récente. |
+| GET | `/run-strategy-by-name` | `strategyName`, `symbol`, `timeframe`, `period`, `comparedSymbol?`, `startDate`, `endDate` | Lancer un calcul de stratégie. |
+| GET | `/backtest` | `strategy` | Résultats de backtest (non exposé dans l'UI actuelle). |
+| GET | `/filter/bullish-bearish-stats/multi-timeframes` | `symbol`, `timeframes` | Statistiques multi-timeframes pour l'analyse bullish/bearish. |
+| GET | `/filter/...` variantes | Selon `selectedAnalysis` : `benford/anomaly`, `institutional-biais`, `contradictory-signals`, `cycles`, `entropy`, `fractal-analysis`, `market-manipulation`, `donchian-channels`, `liquidity`, `lower-timeframe-confluence` avec paramètres `timeframe`, `maxCandle`/`numberLastestCandles`/`period`. | Charger les différents rapports statistiques. |
+| GET | `/api/statistics/historical` *(appel relatif, hôte non défini)* | `symbol`, `timeframes`, `startDate`, `endDate` | Historique de statistiques (non finalisé). |
+
+## Sécurité & Authentification
+- Aucun `AuthGuard`, interceptor JWT/CSRF ou mécanisme de rafraîchissement détecté.
+- Les appels HttpClient utilisent directement l'URL définie dans `environment.apiUrl` (`http://localhost:8090`).
+- Aucune persistance de token ni stockage sécurisé actuellement (auth `unknown`).
+
+## Roadmap d'intégration (suggestions)
+1. Ajouter une authentification (JWT ou OAuth2) avec interceptor pour enrichir les requêtes.
+2. Supporter WebSocket/SSE pour le flux `/api/live-candle` afin de réduire le polling.
+3. Implémenter des endpoints POST pour lancer des backtests paramétrés et suivre leur progression.
+4. Introduire une API d'agrégation des statistiques (heatmaps, saisonnalité) pour enrichir `/statistics`.
+5. Mettre en place des endpoints de pagination/filtrage pour `/all-strategies` et `/get-trades-strategy` (serveur).
+6. Ajouter des services pour récupérer des métadonnées de symboles (ex: description, fuseau horaire).
+7. Centraliser la configuration des plugins Chart.js via un endpoint `/ui-config` pour faciliter les mises à jour.
+8. Intégrer un service d'alerting (webhooks ou email) déclenché par des signaux du backend.
+9. Documenter les schémas de données (DTO) côté backend et générer des types TypeScript partagés.
+10. Sécuriser les appels sensibles via rate limiting côté API et gestion d'erreurs côté client.

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,0 +1,36 @@
+# Front Financial Project Overview
+
+![Node.js](https://img.shields.io/badge/Node.js-unknown-lightgrey) ![Angular](https://img.shields.io/badge/Angular-19.2.0-red)
+
+## Résumé
+Cette application Angular fournit des tableaux de bord financiers pour explorer des bougies historiques, surveiller des flux en direct et analyser la performance de stratégies de trading. Elle s'adresse aux traders quantitatifs, aux analystes financiers et aux équipes produit qui souhaitent visualiser et backtester des stratégies multi-actifs.
+
+## Stack principale
+- **Framework** : Angular 19.2 (standalone components)
+- **Langage** : TypeScript
+- **Librairies clés** : RxJS (~7.8), Chart.js 4 avec `chartjs-chart-financial`, `chartjs-plugin-zoom`, `chartjs-plugin-annotation`, wrapper `ng2-charts`, date-fns
+- **Tooling** : Angular CLI 19, TypeScript 5.7
+
+## Installation & commandes
+```bash
+npm install
+npm run start   # démarrage développement (ng serve)
+npm run build   # build production (ng build)
+```
+
+## Arborescence rapide
+```
+/
+├── angular.json
+├── package.json
+├── public/
+├── src/
+│   ├── app/
+│   │   ├── components/
+│   │   ├── services/
+│   │   └── labs/
+│   ├── environments/
+│   ├── main.ts
+│   └── styles.css
+└── PROJECT_OVERVIEW.md
+```


### PR DESCRIPTION
## Summary
- add a project overview with stack, setup instructions, and structure outline
- document components, services, routes, and state in an architecture map
- catalog features, visualisations, integrations, and roadmap suggestions derived from the Angular app

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e03f5fedbc83239384aba4082a79d0