### PR TITLE
Add dual live charts with independent controls

### DIFF
--- a/src/app/components/live-data/live-data.component.css
+++ b/src/app/components/live-data/live-data.component.css
@@ -1,100 +1,23 @@
-/* Container principal */
-.live-data-container {
-  max-width: 600px;
-  margin: 40px auto;
-  padding: 20px;
-  background-color: #f7f7f7;
-  border-radius: 12px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-}
-
-/* Titre principal */
-.live-data-container h1 {
-  text-align: center;
-  color: #333;
-  margin-bottom: 30px;
-}
-
-/* Sous-titre graphique */
-.live-data-container h2 {
-  text-align: center;
-  margin-top: 40px;
-  color: #333;
-}
-
-/* Groupes de formulaires */
-.form-group {
-  margin-bottom: 20px;
-}
-
-/* Label */
-.form-group label {
-  display: block;
-  margin-bottom: 8px;
-  color: #555;
-  font-weight: 600;
-}
-
-/* Select */
-.form-group select {
-  width: 100%;
-  padding: 12px;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  background-color: #fff;
-  font-size: 16px;
-  box-sizing: border-box;
-}
-
-/* Boutons */
-.button-group {
-  display: flex;
-  justify-content: space-between;
-  gap: 10px;
-  margin-top: 20px;
-}
-
-.button-group button {
-  flex: 1;
-  background-color: #4a90e2;
-  color: white;
-  padding: 12px;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 16px;
-  transition: background-color 0.3s, transform 0.2s;
-}
-
-.button-group button:hover {
-  background-color: #357ABD;
-  transform: translateY(-2px);
-}
-
-.button-group button:disabled {
-  background-color: #aaa;
-  cursor: not-allowed;
-}
-
-/* Message d'attente */
-.live-data-container p {
-  text-align: center;
-  font-style: italic;
-  color: #888;
-}
-
-/* Chart section */
-.chart-section {
-  margin-top: 40px;
-}
-
-/* Responsive */
-@media (max-width: 600px) {
-  .button-group {
-    flex-direction: column;
-  }
-
-  .button-group button {
-    width: 100%;
-  }
-}
+.panels { display: grid; gap: 2rem; }
+.panel { padding: 1.25rem; border: 1px solid #e0e0e0; border-radius: 16px; background: #fff; box-shadow: 0 6px 16px rgba(40, 53, 147, 0.06); }
+.panel-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
+.panel-header h2 { margin: 0; font-size: 1.1rem; color: #1a237e; font-weight: 600; }
+.toolbar { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-end; margin-bottom: 1rem; justify-content: space-between; }
+.control-group { display: flex; flex-wrap: wrap; gap: .75rem; align-items: flex-end; }
+.control { display: flex; flex-direction: column; gap: .25rem; font-size: .85rem; color: #37474f; }
+.control input,
+.control select { padding: .45rem .7rem; border: 1px solid #cfd8dc; border-radius: .65rem; min-width: 140px; font-size: .9rem; transition: border-color .2s ease, box-shadow .2s ease; }
+.control input:focus,
+.control select:focus { outline: none; border-color: #3f51b5; box-shadow: 0 0 0 3px rgba(63, 81, 181, 0.15); }
+.control input:disabled,
+.control select:disabled { background-color: #eceff1; color: #607d8b; cursor: not-allowed; box-shadow: none; }
+.actions { display: flex; align-items: center; gap: .5rem; }
+.actions button { padding: .5rem 1.1rem; border: none; border-radius: .65rem; font-size: .9rem; cursor: pointer; background-color: #3949ab; color: #fff; transition: background-color .2s ease, transform .15s ease; }
+.actions button:hover:not([disabled]) { background-color: #303f9f; transform: translateY(-1px); }
+.actions button[disabled] { background-color: #9fa8da; cursor: not-allowed; }
+.actions button + button { background-color: #546e7a; }
+.actions button + button:hover:not([disabled]) { background-color: #455a64; }
+.actions button + button[disabled] { background-color: #b0bec5; }
+.status { font-weight: 600; margin-left: .5rem; color: #c62828; }
+.status.running { color: #2e7d32; }
+.chart-wrap { position: relative; width: 100%; height: 480px; border: 1px solid #e0e0e0; border-radius: 12px; overflow: hidden; background: #fafafa; }

--- a/src/app/components/live-data/live-data.component.html
+++ b/src/app/components/live-data/live-data.component.html
@@ -1,33 +1,50 @@
-<div class="live-data-container">
+<div class="panels">
+  <div class="panel" *ngFor="let panel of panels; trackBy: trackPanelById">
+    <header class="panel-header">
+      <h2>Live Chart {{ panel.id }}</h2>
+      <span class="status" [class.running]="panel.isRunning">● {{ panel.isRunning ? 'Running' : 'Stopped' }}</span>
+    </header>
 
-  <h1>Données en Direct</h1>
+    <div class="toolbar">
+      <div class="control-group">
+        <label class="control">
+          <span>Provider</span>
+          <select [(ngModel)]="panel.provider" (ngModelChange)="onProviderChange(panel)" [disabled]="panel.isRunning">
+            <option *ngFor="let providerOption of dataProviders" [ngValue]="providerOption.value">
+              {{ providerOption.label }}
+            </option>
+          </select>
+        </label>
 
-  <div class="form-group">
-    <label for="symbol">Symbole :</label>
-    <select id="symbol" [(ngModel)]="selectedSymbol">
-      <option *ngFor="let symbol of symbols" [value]="symbol">{{ symbol }}</option>
-    </select>
+        <label class="control">
+          <span>Market</span>
+          <input
+            type="text"
+            [(ngModel)]="panel.pair"
+            (ngModelChange)="onPairChange(panel)"
+            [disabled]="panel.isRunning"
+            placeholder="EURUSD"
+          />
+        </label>
+
+        <label class="control">
+          <span>Timeframe</span>
+          <select [(ngModel)]="panel.barSize" (ngModelChange)="onBarSizeChange(panel)" [disabled]="panel.isRunning">
+            <option *ngFor="let option of barSizeOptions" [ngValue]="option.value">
+              {{ option.label }}
+            </option>
+          </select>
+        </label>
+      </div>
+
+      <div class="actions">
+        <button (click)="start(panel)" [disabled]="panel.isRunning">Start</button>
+        <button (click)="stop(panel)" [disabled]="!panel.isRunning">Stop</button>
+      </div>
+    </div>
+
+    <div class="chart-wrap">
+      <canvas #liveCanvas></canvas>
+    </div>
   </div>
-
-  <div class="form-group">
-    <label for="timeframe">Timeframe :</label>
-    <select id="timeframe" [(ngModel)]="selectedTimeframe">
-      <option *ngFor="let tf of timeframes" [value]="tf">{{ tf }}</option>
-    </select>
-  </div>
-
-  <div class="button-group">
-    <button (click)="startLive()" [disabled]="isStreaming">Démarrer le stream</button>
-    <button (click)="stopLive()" [disabled]="!isStreaming">Stopper le stream</button>
-  </div>
-
-  <div *ngIf="candles.length > 0; else waiting" class="chart-section">
-    <h2>Graphique Live des Bougies</h2>
-    <canvas id="liveCandlestickChart"></canvas>
-  </div>
-
-  <ng-template #waiting>
-    <p>En attente de données live...</p>
-  </ng-template>
-
 </div>

--- a/src/app/components/live-data/live-data.component.ts
+++ b/src/app/components/live-data/live-data.component.ts
@@ -1,160 +1,352 @@
-import { Component, OnDestroy, AfterViewInit } from '@angular/core';
-import { NgChartsModule } from 'ng2-charts';
 import { CommonModule } from '@angular/common';
-import { Chart, registerables } from 'chart.js';
-import { TradingDataService } from '../../services/trading-data.service';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  OnDestroy,
+  QueryList,
+  ViewChildren
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Subject, Subscription, of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { Chart, ChartConfiguration, registerables } from 'chart.js';
 import 'chartjs-chart-financial';
 import 'chartjs-adapter-date-fns';
 import zoomPlugin from 'chartjs-plugin-zoom';
-import { CandlestickController, CandlestickElement, OhlcController } from 'chartjs-chart-financial';
-import { FormsModule } from '@angular/forms';
+import { CandlestickController, CandlestickElement, OhlcController, OhlcElement } from 'chartjs-chart-financial';
+import { TradingDataService } from '../../services/trading-data.service';
+
+Chart.register(
+  ...registerables,
+  CandlestickController,
+  CandlestickElement,
+  OhlcController,
+  OhlcElement,
+  zoomPlugin
+);
+
+interface LiveChartPanel {
+  id: number;
+  provider: string;
+  pair: string;
+  duration: string;
+  barSize: string;
+  pollMs: number;
+  chart?: Chart<'candlestick'>;
+  stop$?: Subject<void>;
+  sub?: Subscription;
+  connectSub?: Subscription;
+  reqId?: number;
+  isRunning: boolean;
+}
 
 @Component({
-  selector: 'app-live-data',
   standalone: true,
-  imports: [CommonModule, NgChartsModule, FormsModule],
+  selector: 'app-live-data',
+  imports: [CommonModule, FormsModule],
   templateUrl: './live-data.component.html',
-  styleUrl: './live-data.component.css'
+  styleUrls: ['./live-data.component.css']
 })
 export class LiveDataComponent implements AfterViewInit, OnDestroy {
+  @ViewChildren('liveCanvas') liveCanvasRefs!: QueryList<ElementRef<HTMLCanvasElement>>;
 
-  chart: any;
-  candles: any[] = [];
+  readonly barSizeOptions = [
+    { value: '1 min', label: '1 minute', timeUnit: 'minute' as const },
+    { value: '5 mins', label: '5 minutes', timeUnit: 'minute' as const },
+    { value: '15 mins', label: '15 minutes', timeUnit: 'minute' as const },
+    { value: '1 hour', label: '1 hour', timeUnit: 'hour' as const },
+    { value: '4 hours', label: '4 hours', timeUnit: 'hour' as const },
+    { value: '1 day', label: '1 day', timeUnit: 'day' as const }
+  ];
 
-  symbols = ['EURUSD', 'GBPUSD', 'USDJPY', 'NASDAQ', 'SP500'];
-  timeframes = ['M1', 'M5', 'M15', 'M30', 'H1', 'H4', 'D1'];
+  readonly dataProviders = [
+    { value: 'ibkr', label: 'IBKR' }
+  ];
 
-  selectedSymbol = 'EURUSD';
-  selectedTimeframe = 'M1';
+  private canvasChangesSub?: Subscription;
 
-  isStreaming = false;
-  liveInterval: any; // Pour le polling ou mock de données en live
+  readonly panels: LiveChartPanel[] = [
+    {
+      id: 1,
+      provider: this.dataProviders[0].value,
+      pair: 'EURUSD',
+      duration: '1 D',
+      barSize: this.barSizeOptions[0].value,
+      pollMs: 1000,
+      isRunning: false
+    },
+    {
+      id: 2,
+      provider: this.dataProviders[0].value,
+      pair: 'GBPUSD',
+      duration: '1 D',
+      barSize: this.barSizeOptions[2].value,
+      pollMs: 1000,
+      isRunning: false
+    }
+  ];
 
-  constructor(private tradingService: TradingDataService) {
-    Chart.register(...registerables, CandlestickElement, OhlcController, CandlestickController, zoomPlugin);
+  constructor(private readonly data: TradingDataService) {}
+
+  ngAfterViewInit(): void {
+    this.initializeCharts();
+    this.canvasChangesSub = this.liveCanvasRefs.changes.subscribe(() => this.initializeCharts());
   }
 
-  ngAfterViewInit() {
-    this.initChart();
+  ngOnDestroy(): void {
+    this.canvasChangesSub?.unsubscribe();
+    this.panels.forEach(panel => {
+      this.stop(panel, { skipStopRequest: true });
+      panel.chart?.destroy();
+    });
   }
 
-  ngOnDestroy() {
-    this.stopLive();
-  }
-
-  initChart() {
-    const canvas = document.getElementById('liveCandlestickChart') as HTMLCanvasElement;
-    if (!canvas) {
-      console.error('Canvas not found!');
+  start(panel: LiveChartPanel): void {
+    if (panel.isRunning) {
       return;
     }
 
+    panel.isRunning = true;
+    panel.stop$ = new Subject<void>();
+    panel.reqId = undefined;
+    this.resetDataset(panel);
+
+    panel.connectSub?.unsubscribe();
+    panel.connectSub = this.data.ibkrStatus().pipe(
+      switchMap(status => (status?.connected ? of(status) : this.data.ibkrConnectWait()))
+    ).subscribe({
+      next: () => {
+        if (panel.provider !== 'ibkr') {
+          console.warn(`Provider ${panel.provider} not supported yet.`);
+          this.stop(panel);
+          return;
+        }
+
+        const selectedPair = panel.pair.trim();
+        if (!selectedPair) {
+          console.warn('Please provide a market symbol before starting the live stream.');
+          this.stop(panel);
+          return;
+        }
+
+        panel.sub = this.data
+          .streamIbkrBars(
+            { pair: selectedPair, duration: panel.duration, barSize: panel.barSize, pollMs: panel.pollMs },
+            panel.stop$
+          )
+          .subscribe({
+            next: (event) => {
+              if (!panel.reqId) {
+                panel.reqId = event.reqId;
+              }
+
+              if (event.mode === 'bootstrap' && event.bars?.length) {
+                const dataset = this.ensureDataset(panel);
+                dataset.data = event.bars.map(bar => this.data.toFinancialPoint(bar));
+                this.updateDatasetMeta(panel);
+              } else if (event.mode === 'update' && event.bar) {
+                this.upsertLast(panel, event.bar);
+              }
+            },
+            error: (err) => {
+              console.error('Live stream error', err);
+              this.stop(panel);
+            }
+          });
+      },
+      error: (err) => {
+        console.error('IBKR connect/status failed', err);
+        this.stop(panel);
+      }
+    });
+  }
+
+  stop(panel: LiveChartPanel, options: { skipStopRequest?: boolean } = {}): void {
+    if (panel.stop$ && !panel.stop$.closed) {
+      panel.stop$.next();
+      panel.stop$.complete();
+    }
+
+    panel.stop$ = undefined;
+
+    panel.sub?.unsubscribe();
+    panel.sub = undefined;
+
+    panel.connectSub?.unsubscribe();
+    panel.connectSub = undefined;
+
+    const currentReqId = panel.reqId;
+    panel.reqId = undefined;
+
+    if (!options.skipStopRequest && currentReqId != null) {
+      this.data.ibkrStopLiveBars(currentReqId).subscribe({
+        error: (err) => {
+          console.error('Error stopping IBKR stream', err);
+        }
+      });
+    }
+
+    panel.isRunning = false;
+  }
+
+  onPairChange(panel: LiveChartPanel): void {
+    if (!panel.isRunning) {
+      this.updateDatasetMeta(panel);
+    }
+  }
+
+  onProviderChange(panel: LiveChartPanel): void {
+    if (!panel.isRunning) {
+      this.updateDatasetMeta(panel);
+    }
+  }
+
+  onBarSizeChange(panel: LiveChartPanel): void {
+    if (!panel.isRunning) {
+      this.updateDatasetMeta(panel);
+    }
+    this.updateTimeScale(panel);
+  }
+
+  trackPanelById(_index: number, panel: LiveChartPanel): number {
+    return panel.id;
+  }
+
+  private initializeCharts(): void {
+    this.panels.forEach((panel, index) => {
+      if (!panel.chart) {
+        const canvas = this.liveCanvasRefs.get(index);
+        if (canvas) {
+          this.initChartForPanel(panel, canvas.nativeElement);
+        }
+      }
+    });
+  }
+
+  private initChartForPanel(panel: LiveChartPanel, canvas: HTMLCanvasElement): void {
     const ctx = canvas.getContext('2d');
     if (!ctx) {
-      console.error('Could not get canvas context!');
-      return;
+      throw new Error('Unable to acquire chart context');
     }
 
-    if (this.chart) this.chart.destroy();
+    panel.chart = new Chart(ctx, this.buildConfig(panel));
+    this.updateTimeScale(panel);
+  }
 
-    this.chart = new Chart(ctx, {
+  private buildConfig(panel: LiveChartPanel): ChartConfiguration<'candlestick'> {
+    const barSizeMeta = this.getSelectedBarSizeMeta(panel.barSize);
+    return {
       type: 'candlestick',
       data: {
         datasets: [
           {
-            label: `${this.selectedSymbol} - ${this.selectedTimeframe}`,
-            data: [],
-            borderColor: 'black',
-            backgroundColor: 'rgba(0, 128, 0, 0.5)',
-            barThickness: 1,
+            label: this.buildDatasetLabel(panel),
+            data: []
           }
         ]
       },
       options: {
-        responsive: true,
+        parsing: false,
+        animation: false,
+        maintainAspectRatio: false,
         scales: {
           x: {
             type: 'time',
-            time: {
-              unit: 'minute'
-            }
+            time: { unit: barSizeMeta?.timeUnit ?? 'minute' }
           },
           y: {
             beginAtZero: false
           }
         },
         plugins: {
+          legend: { display: true },
           zoom: {
-            pan: {
-              enabled: true,
-              mode: 'x'
-            },
+            pan: { enabled: true, mode: 'x' },
             zoom: {
-              wheel: {
-                enabled: true
-              },
+              wheel: { enabled: true },
+              pinch: { enabled: true },
               mode: 'x'
             }
           }
         }
       }
-    });
+    };
   }
 
-  startLive() {
-    if (this.isStreaming) {
-      console.warn('Stream déjà en cours');
+  private ensureDataset(panel: LiveChartPanel) {
+    if (!panel.chart) {
+      throw new Error('Chart not initialised for panel');
+    }
+    const dataset = panel.chart.data.datasets[0] as any;
+    if (!Array.isArray(dataset.data)) {
+      dataset.data = [];
+    }
+    return dataset;
+  }
+
+  private resetDataset(panel: LiveChartPanel): void {
+    if (!panel.chart) {
       return;
     }
-
-    this.isStreaming = true;
-    this.candles = [];
-
-    this.initChart();
-
-    // 🔴 Ex: On fait un polling toutes les secondes
-    this.liveInterval = setInterval(() => {
-      this.fetchLiveCandle();
-    }, 1000); // Chaque seconde, ou remplace par un websocket dans le futur
+    const dataset = this.ensureDataset(panel);
+    dataset.data = [];
+    this.updateDatasetMeta(panel);
+    this.updateTimeScale(panel);
   }
 
-  stopLive() {
-    if (this.liveInterval) {
-      clearInterval(this.liveInterval);
-      this.liveInterval = null;
+  private upsertLast(panel: LiveChartPanel, bar: { time: number | string; open: number; high: number; low: number; close: number }): void {
+    const dataset = this.ensureDataset(panel);
+    const nextPoint = this.data.toFinancialPoint(bar);
+    const lastPoint = dataset.data.at(-1);
+
+    const lastTimestamp = lastPoint ? new Date(lastPoint.t).getTime() : undefined;
+    const nextTimestamp = this.data.toEpochMs(bar.time);
+
+    if (lastPoint && lastTimestamp === nextTimestamp) {
+      lastPoint.h = Math.max(lastPoint.h, nextPoint.h);
+      lastPoint.l = Math.min(lastPoint.l, nextPoint.l);
+      lastPoint.c = nextPoint.c;
+    } else {
+      dataset.data.push(nextPoint);
     }
-    this.isStreaming = false;
+
+    panel.chart?.update('none');
   }
 
-  fetchLiveCandle() {
-    // Appelle ton service pour récupérer la dernière bougie en live
-    this.tradingService.getLiveCandle(this.selectedSymbol, this.selectedTimeframe)
-      .subscribe(latestCandle => {
-
-        // ➡️ Si déjà une candle pour ce timestamp, on la met à jour
-        const lastCandle = this.candles[this.candles.length - 1];
-
-        if (lastCandle && new Date(latestCandle.date).getTime() === new Date(lastCandle.date).getTime()) {
-          this.candles[this.candles.length - 1] = latestCandle;
-        } else {
-          this.candles.push(latestCandle);
-        }
-
-        this.updateChart();
-      });
+  private updateDatasetMeta(panel: LiveChartPanel): void {
+    if (!panel.chart) {
+      return;
+    }
+    const dataset = this.ensureDataset(panel);
+    dataset.label = this.buildDatasetLabel(panel);
+    panel.chart.update('none');
   }
 
-  updateChart() {
-    if (!this.chart) return;
+  private buildDatasetLabel(panel: LiveChartPanel): string {
+    const barSizeLabel = this.getSelectedBarSizeMeta(panel.barSize)?.label ?? panel.barSize;
+    const providerLabel = this.getProviderLabel(panel.provider);
+    return `${panel.pair.trim() || '—'} · ${barSizeLabel}${providerLabel ? ` · ${providerLabel}` : ''}`;
+  }
 
-    this.chart.data.datasets[0].data = this.candles.map(c => ({
-      x: new Date(c.date).getTime(),
-      o: c.open,
-      h: c.high,
-      l: c.low,
-      c: c.close
-    }));
+  private getProviderLabel(provider: string): string {
+    return this.dataProviders.find(p => p.value === provider)?.label ?? '';
+  }
 
-    this.chart.update();
+  private getSelectedBarSizeMeta(barSize: string) {
+    return this.barSizeOptions.find(option => option.value === barSize);
+  }
+
+  private updateTimeScale(panel: LiveChartPanel): void {
+    if (!panel.chart?.options?.scales) {
+      return;
+    }
+    const meta = this.getSelectedBarSizeMeta(panel.barSize);
+    const timeUnit = meta?.timeUnit ?? 'minute';
+    const xScale: any = panel.chart.options.scales['x'];
+    if (xScale?.time) {
+      xScale.time.unit = timeUnit;
+      panel.chart.update('none');
+    }
   }
 }

--- a/src/app/models/hist-bar.model.ts
+++ b/src/app/models/hist-bar.model.ts
@@ -1,0 +1,28 @@
+export interface HistBar {
+  // IBKR avec formatDate=2 renvoie en général epoch (secondes). On gère ms/sec/ISO.
+  time: number | string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume?: number;
+}
+
+export function toEpochMs(t: number | string): number {
+  if (typeof t === 'number') {
+    // Heuristique: si < 10^12 → secondes -> ms.
+    return t < 1_000_000_000_000 ? t * 1000 : t;
+  }
+  // string ISO ou epoch string
+  const n = Number(t);
+  if (!Number.isNaN(n)) {
+    return n < 1_000_000_000_000 ? n * 1000 : n;
+  }
+  const d = new Date(t).getTime();
+  return Number.isNaN(d) ? Date.now() : d;
+}
+
+export function toFinancialPoint(b: HistBar) {
+  const ts = toEpochMs(b.time);
+  return { t: new Date(ts), o: b.open, h: b.high, l: b.low, c: b.close };
+}

--- a/src/app/services/trading-data.service.ts
+++ b/src/app/services/trading-data.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, Subject, concat, interval } from 'rxjs';
+import { map, shareReplay, switchMap, takeUntil } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
+import { HistBar, toEpochMs as histToEpochMs, toFinancialPoint as histToFinancialPoint } from '../models/hist-bar.model';
 
 export interface SymbolDTO {
   id: string;
@@ -17,6 +19,88 @@ export class TradingDataService {
   private apiUrl = environment.apiUrl;
 
   constructor(private http: HttpClient) {}
+
+  // --- IBKR status / connect (optionnel mais utile) ---
+  ibkrStatus(): Observable<{ connected: boolean }> {
+    return this.http.get<{ connected: boolean }>(`${this.apiUrl}/ibkr/status`);
+  }
+
+  ibkrConnectWait(host = '127.0.0.1', port = 7497, clientId = 1, timeoutMs = 3000): Observable<any> {
+    const params = new HttpParams()
+      .set('host', host)
+      .set('port', port)
+      .set('clientId', clientId)
+      .set('timeoutMs', timeoutMs);
+    return this.http.post(`${this.apiUrl}/ibkr/connect/wait`, null, { params });
+  }
+
+  // --- Start/Stop bars ---
+  ibkrStartLiveBars(opts: {
+    pair: string; duration?: string; barSize?: string; what?: string; rth?: number; formatDate?: number;
+  }): Observable<{ reqId: number }> {
+    const params = new HttpParams()
+      .set('pair', opts.pair)
+      .set('duration', opts.duration ?? '1 D')
+      .set('barSize', opts.barSize ?? '1 min')
+      .set('what', opts.what ?? 'MIDPOINT')
+      .set('rth', String(opts.rth ?? 0))
+      .set('formatDate', String(opts.formatDate ?? 2));
+    return this.http.post<{ reqId: number }>(`${this.apiUrl}/ibkr/live/bars/start`, null, { params });
+  }
+
+  ibkrStopLiveBars(reqId: number): Observable<{ stopped: boolean }> {
+    return this.http.post<{ stopped: boolean }>(`${this.apiUrl}/ibkr/live/bars/stop/${reqId}`, null);
+  }
+
+  // --- Bootstrap & updates ---
+  ibkrRecentLiveBars(reqId: number): Observable<HistBar[]> {
+    return this.http.get<HistBar[]>(`${this.apiUrl}/ibkr/live/bars/${reqId}`);
+  }
+
+  ibkrGetLastLiveBar(reqId: number): Observable<HistBar> {
+    return this.http.get<HistBar>(`${this.apiUrl}/ibkr/live/bars/${reqId}/last`);
+  }
+
+  streamIbkrBars(params: {
+    pair: string; duration?: string; barSize?: string; pollMs?: number;
+  }, stop$: Subject<void>): Observable<
+    | { reqId: number; mode: 'bootstrap'; bars: HistBar[] }
+    | { reqId: number; mode: 'update'; bar: HistBar }
+  > {
+    const pollMs = params.pollMs ?? 1000;
+
+    return this.ibkrStartLiveBars({
+      pair: params.pair,
+      duration: params.duration,
+      barSize: params.barSize
+    }).pipe(
+      switchMap(({ reqId }) => {
+        const bootstrap$ = this.ibkrRecentLiveBars(reqId).pipe(
+          map(list => ({
+            reqId,
+            mode: 'bootstrap' as const,
+            bars: [...list].sort((a, b) => histToEpochMs(a.time) - histToEpochMs(b.time))
+          })),
+          takeUntil(stop$)
+        );
+
+        const updates$ = interval(pollMs).pipe(
+          takeUntil(stop$),
+          switchMap(() => this.ibkrGetLastLiveBar(reqId)),
+          map(bar => ({ reqId, mode: 'update' as const, bar }))
+        );
+
+        return concat(bootstrap$, updates$).pipe(
+          takeUntil(stop$),
+          shareReplay({ bufferSize: 1, refCount: true })
+        );
+      }),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+  }
+
+  toFinancialPoint = histToFinancialPoint;
+  toEpochMs = histToEpochMs;
 
   getCandlesForTrade(tradeId: number, timeframe: string, symbol: string, comparedSymbol: string, beforeCandles: number = 50, afterCandles: number = 50) {
     console.log(symbol);


### PR DESCRIPTION
## Summary
- refactor the live data component to manage two independent live-stream panels backed by shared chart helpers
- update the live data template so each panel exposes its own provider, market, and timeframe controls with start/stop actions
- refresh component styles to lay out the twin panels with clearer grouping and visual hierarchy

## Testing
- npm run build *(fails: ng not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f28041cc1083239e22971c1fe4b85e