### PR TITLE
Add live signal chart and SSE stream to live data view

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## Live page overlay
+
+The live monitoring page now embeds an OHLC viewer and a real-time signals list:
+
+- The chart requests data from `GET /marketdata/ohlcv/window` to draw the 50 candles leading to the selected entry and extends to the exit candle when `payload.exitTsUtc`/`payload.exitPrice` are present.
+- The signals table subscribes to the Server-Sent Events stream exposed at `/live/stream`. Each incoming trade is appended in real time (the UI keeps the latest 200 entries) and clicking a row reloads the OHLC window.
+- The view depends on the [`lightweight-charts`](https://github.com/tradingview/lightweight-charts) package for rendering candlesticks.

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
 
-## Live page overlay
+## Robots actifs overlay
 
-The live monitoring page now embeds an OHLC viewer and a real-time signals list:
+La page « Robots actifs » propose désormais un graphique OHLC et un tableau de signaux en temps réel :
 
-- The chart requests data from `GET /marketdata/ohlcv/window` to draw the 50 candles leading to the selected entry and extends to the exit candle when `payload.exitTsUtc`/`payload.exitPrice` are present.
-- The signals table subscribes to the Server-Sent Events stream exposed at `/live/stream`. Each incoming trade is appended in real time (the UI keeps the latest 200 entries) and clicking a row reloads the OHLC window.
-- The view depends on the [`lightweight-charts`](https://github.com/tradingview/lightweight-charts) package for rendering candlesticks.
+- Le graphique interroge `GET /marketdata/ohlcv/window` pour afficher les 50 bougies précédant l’entrée sélectionnée et prolonge jusqu’à la sortie lorsque `payload.exitTsUtc`/`payload.exitPrice` sont fournis.
+- Le tableau des signaux s’abonne au flux Server-Sent Events `/live/stream`. Chaque trade reçu est ajouté en temps réel (les 200 derniers sont conservés) et un clic sur une ligne recharge la fenêtre OHLC.
+- L’affichage repose sur la bibliothèque [`lightweight-charts`](https://github.com/tradingview/lightweight-charts) pour le rendu des chandeliers.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "chartjs-plugin-annotation": "^3.1.0",
     "chartjs-plugin-zoom": "^2.2.0",
     "date-fns": "^4.1.0",
+    "lightweight-charts": "^4.2.1",
     "ng2-charts": "^4.1.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { StrategyCalculationComponent } from './components/strategy-calculation/
 import {ScreenStrategiesComponent} from './components/screen-strategies/screen-strategies.component';
 import {StrategyDetailComponent} from './components/strategy-detail/strategy-detail.component';
 import {LiveDataComponent} from './components/live-data/live-data.component'; // 🆕
+import {ActiveRobotsComponent} from './components/active-robots/active-robots.component';
 
 export const routes: Routes = [
   { path: 'historical-data', component: HistoricalDataComponent },
@@ -13,6 +14,7 @@ export const routes: Routes = [
   { path: 'screen-strategies', component: ScreenStrategiesComponent },
   { path: 'strategy-detail/:name/:runId/:symbol/:comparedSymbol', component: StrategyDetailComponent },
   { path: 'live-data', component: LiveDataComponent },
+  { path: 'active-robots', component: ActiveRobotsComponent },
   {
     path: '_lab/signals',
     loadChildren: () => import('./labs/signals/signals.routes').then(m => m.SIGNALS_ROUTES)

--- a/src/app/components/active-robots/active-robots.component.html
+++ b/src/app/components/active-robots/active-robots.component.html
@@ -1,0 +1,116 @@
+<div class="active-robots-page">
+  <header class="page-header">
+    <div>
+      <h1>Robots actifs</h1>
+      <p>Visualisez l'activité des marchés surveillés et pilotez vos robots par broker et timeframe.</p>
+    </div>
+  </header>
+
+  <section class="filters">
+    <label>
+      <span>Broker</span>
+      <select [formControl]="brokerControl">
+        <option *ngFor="let option of brokerOptions" [value]="option.value">
+          {{ option.label }}
+        </option>
+      </select>
+    </label>
+
+    <label>
+      <span>Timeframe</span>
+      <select [formControl]="timeframeControl">
+        <option *ngFor="let option of timeframeOptions" [value]="option.value">
+          {{ option.label }}
+        </option>
+      </select>
+    </label>
+  </section>
+
+  <div class="tables-grid">
+    <section class="panel markets-panel">
+      <header>
+        <h2>Marchés surveillés</h2>
+        <span class="panel-count">{{ filteredMarkets.length }} marché{{ filteredMarkets.length > 1 ? 's' : '' }}</span>
+      </header>
+
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Marché</th>
+              <th>Timeframe</th>
+              <th>Durée d'écoute</th>
+              <th>Robots actifs</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let market of filteredMarkets">
+              <td>
+                <div class="cell-main">
+                  <span class="title">{{ market.market }}</span>
+                  <span class="subtitle">{{ market.broker }}</span>
+                </div>
+              </td>
+              <td>{{ market.timeframe }}</td>
+              <td>{{ formatDurationSince(market.startedAt) }}</td>
+              <td>
+                <span class="badge">{{ market.robotsListening }}</span>
+              </td>
+            </tr>
+            <tr *ngIf="filteredMarkets.length === 0">
+              <td colspan="4" class="empty">Aucun marché ne correspond à ces filtres.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="panel robots-panel">
+      <header>
+        <h2>Robots</h2>
+        <span class="panel-count">{{ filteredRobots.length }} robot{{ filteredRobots.length > 1 ? 's' : '' }}</span>
+      </header>
+
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Stratégie</th>
+              <th>Marché</th>
+              <th>Timeframes</th>
+              <th>Durée</th>
+              <th>État</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let robot of filteredRobots">
+              <td>
+                <div class="cell-main">
+                  <span class="title">{{ robot.strategyName }}</span>
+                  <span class="subtitle">{{ robot.broker }}</span>
+                </div>
+              </td>
+              <td>{{ robot.market }}</td>
+              <td>{{ robot.timeframes.join(', ') }}</td>
+              <td>{{ formatDurationSince(robot.startedAt) }}</td>
+              <td>
+                <span class="status" [class.active]="robot.active" [class.inactive]="!robot.active">
+                  {{ getRobotStateLabel(robot) }}
+                </span>
+              </td>
+              <td>
+                <button type="button" class="action" [class.stop]="robot.active" (click)="toggleRobot(robot)">
+                  {{ robot.active ? 'Stop' : 'Start' }}
+                </button>
+              </td>
+            </tr>
+            <tr *ngIf="filteredRobots.length === 0">
+              <td colspan="6" class="empty">Aucun robot ne correspond à ces filtres.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</div>

--- a/src/app/components/active-robots/active-robots.component.html
+++ b/src/app/components/active-robots/active-robots.component.html
@@ -113,4 +113,13 @@
       </div>
     </section>
   </div>
+
+  <div class="live-bottom-split">
+    <div class="left">
+      <app-live-signal-chart [signal]="selectedSignal"></app-live-signal-chart>
+    </div>
+    <div class="right">
+      <app-live-signals-table (select)="onSelectSignal($event)"></app-live-signals-table>
+    </div>
+  </div>
 </div>

--- a/src/app/components/active-robots/active-robots.component.scss
+++ b/src/app/components/active-robots/active-robots.component.scss
@@ -1,0 +1,220 @@
+:host {
+  display: block;
+  padding: 1.75rem;
+  box-sizing: border-box;
+  background: #f8fafc;
+  min-height: 100%;
+}
+
+.active-robots-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.page-header p {
+  margin: 0.35rem 0 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.filters {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  background: #ffffff;
+  padding: 1.25rem 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: #475569;
+  min-width: 180px;
+}
+
+.filters select {
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 0.55rem 0.75rem;
+  font-size: 0.95rem;
+  color: #0f172a;
+  background: #f8fafc;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filters select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  background: #ffffff;
+}
+
+.tables-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: #ffffff;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 10px 32px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+}
+
+.panel header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.panel header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.panel-count {
+  font-size: 0.9rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.75rem 0.85rem;
+  text-align: left;
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #475569;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+tbody tr:not(:last-child) td {
+  border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.cell-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.cell-main .title {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.cell-main .subtitle {
+  font-size: 0.8rem;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status.active {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.status.inactive {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.action {
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(34, 197, 94, 0.1);
+  color: #15803d;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.action.stop {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.1);
+}
+
+.empty {
+  text-align: center;
+  padding: 1.5rem;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+@media (max-width: 960px) {
+  :host {
+    padding: 1.25rem;
+  }
+
+  .tables-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/components/active-robots/active-robots.component.scss
+++ b/src/app/components/active-robots/active-robots.component.scss
@@ -68,6 +68,28 @@
   gap: 1.5rem;
 }
 
+.live-bottom-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 420px;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.live-bottom-split .left,
+.live-bottom-split .right {
+  min-height: 420px;
+}
+
+app-live-signal-chart,
+app-live-signals-table {
+  display: block;
+  height: 100%;
+}
+
+app-live-signals-table {
+  overflow: auto;
+}
+
 .panel {
   background: #ffffff;
   border-radius: 14px;
@@ -215,6 +237,10 @@ tbody tr:not(:last-child) td {
   }
 
   .tables-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .live-bottom-split {
     grid-template-columns: 1fr;
   }
 }

--- a/src/app/components/active-robots/active-robots.component.ts
+++ b/src/app/components/active-robots/active-robots.component.ts
@@ -4,6 +4,10 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Subject, merge } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
+import { LiveSignal } from '../../models/live-signal.model';
+import { LiveSignalChartComponent } from '../live-signal-chart/live-signal-chart.component';
+import { LiveSignalsTableComponent } from '../live-signals-table/live-signals-table.component';
+import { LiveSignalsService } from '../../services/live-signals.service';
 
 type BrokerOption = {
   value: string;
@@ -35,7 +39,7 @@ interface RobotStatus {
 @Component({
   selector: 'app-active-robots',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, LiveSignalChartComponent, LiveSignalsTableComponent],
   templateUrl: './active-robots.component.html',
   styleUrls: ['./active-robots.component.scss']
 })
@@ -70,8 +74,12 @@ export class ActiveRobotsComponent implements OnInit, OnDestroy {
 
   filteredMarkets: MarketListening[] = [];
   filteredRobots: RobotStatus[] = [];
+  selectedSignal: LiveSignal | null = null;
 
-  constructor(private readonly route: ActivatedRoute) {
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly liveSignalsService: LiveSignalsService
+  ) {
     const brokers = Array.from(new Set([...this.markets, ...this.robots].map(item => item.broker))).sort();
     this.brokerOptions = [
       { value: 'ALL', label: 'Tous les brokers' },
@@ -86,6 +94,13 @@ export class ActiveRobotsComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this.liveSignalsService.connect();
+    this.liveSignalsService.selected$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(signal => {
+        this.selectedSignal = signal;
+      });
+
     merge(
       this.brokerControl.valueChanges,
       this.timeframeControl.valueChanges
@@ -110,10 +125,15 @@ export class ActiveRobotsComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+    this.liveSignalsService.disconnect();
   }
 
   toggleRobot(robot: RobotStatus): void {
     robot.active = !robot.active;
+  }
+
+  onSelectSignal(signal: LiveSignal): void {
+    this.selectedSignal = signal;
   }
 
   formatDurationSince(startedAt: string): string {

--- a/src/app/components/active-robots/active-robots.component.ts
+++ b/src/app/components/active-robots/active-robots.component.ts
@@ -1,0 +1,168 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { Subject, merge } from 'rxjs';
+import { startWith, takeUntil } from 'rxjs/operators';
+
+type BrokerOption = {
+  value: string;
+  label: string;
+};
+
+type TimeframeOption = {
+  value: string;
+  label: string;
+};
+
+interface MarketListening {
+  broker: string;
+  market: string;
+  timeframe: string;
+  startedAt: string;
+  robotsListening: number;
+}
+
+interface RobotStatus {
+  broker: string;
+  strategyName: string;
+  market: string;
+  timeframes: string[];
+  startedAt: string;
+  active: boolean;
+}
+
+@Component({
+  selector: 'app-active-robots',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './active-robots.component.html',
+  styleUrls: ['./active-robots.component.scss']
+})
+export class ActiveRobotsComponent implements OnInit, OnDestroy {
+  private readonly destroy$ = new Subject<void>();
+
+  readonly markets: MarketListening[] = [
+    { broker: 'IBKR', market: 'EURUSD', timeframe: '15m', startedAt: this.hoursAgo(26), robotsListening: 3 },
+    { broker: 'IBKR', market: 'GBPUSD', timeframe: '1h', startedAt: this.hoursAgo(78), robotsListening: 2 },
+    { broker: 'IBKR', market: 'AAPL', timeframe: '5m', startedAt: this.hoursAgo(12), robotsListening: 4 },
+    { broker: 'MEXC', market: 'BTCUSDT', timeframe: '1h', startedAt: this.hoursAgo(130), robotsListening: 6 },
+    { broker: 'MEXC', market: 'ETHUSDT', timeframe: '30m', startedAt: this.hoursAgo(55), robotsListening: 5 },
+    { broker: 'BINANCE', market: 'SOLUSDT', timeframe: '15m', startedAt: this.hoursAgo(98), robotsListening: 4 },
+    { broker: 'BINANCE', market: 'BNBUSDT', timeframe: '4h', startedAt: this.hoursAgo(240), robotsListening: 1 }
+  ];
+
+  readonly robots: RobotStatus[] = [
+    { broker: 'IBKR', strategyName: 'Mean Reversion FX', market: 'EURUSD', timeframes: ['5m', '15m'], startedAt: this.hoursAgo(26), active: true },
+    { broker: 'IBKR', strategyName: 'London Breakout', market: 'GBPUSD', timeframes: ['1h'], startedAt: this.hoursAgo(78), active: false },
+    { broker: 'IBKR', strategyName: 'Momentum Tech', market: 'AAPL', timeframes: ['5m', '15m'], startedAt: this.hoursAgo(12), active: true },
+    { broker: 'MEXC', strategyName: 'Crypto Swing', market: 'BTCUSDT', timeframes: ['1h', '4h'], startedAt: this.hoursAgo(130), active: true },
+    { broker: 'MEXC', strategyName: 'DeFi Scalper', market: 'ETHUSDT', timeframes: ['15m', '30m'], startedAt: this.hoursAgo(55), active: false },
+    { broker: 'BINANCE', strategyName: 'Layer-1 Tracker', market: 'SOLUSDT', timeframes: ['15m'], startedAt: this.hoursAgo(98), active: true },
+    { broker: 'BINANCE', strategyName: 'BNB Range', market: 'BNBUSDT', timeframes: ['4h'], startedAt: this.hoursAgo(240), active: false }
+  ];
+
+  readonly brokerOptions: BrokerOption[];
+  readonly timeframeOptions: TimeframeOption[];
+
+  readonly brokerControl = new FormControl('ALL', { nonNullable: true });
+  readonly timeframeControl = new FormControl('ALL', { nonNullable: true });
+
+  filteredMarkets: MarketListening[] = [];
+  filteredRobots: RobotStatus[] = [];
+
+  constructor(private readonly route: ActivatedRoute) {
+    const brokers = Array.from(new Set([...this.markets, ...this.robots].map(item => item.broker))).sort();
+    this.brokerOptions = [
+      { value: 'ALL', label: 'Tous les brokers' },
+      ...brokers.map(broker => ({ value: broker, label: broker }))
+    ];
+
+    const timeframes = Array.from(new Set(this.markets.map(market => market.timeframe))).sort((a, b) => a.localeCompare(b));
+    this.timeframeOptions = [
+      { value: 'ALL', label: 'Toutes les timeframes' },
+      ...timeframes.map(tf => ({ value: tf, label: tf }))
+    ];
+  }
+
+  ngOnInit(): void {
+    merge(
+      this.brokerControl.valueChanges,
+      this.timeframeControl.valueChanges
+    )
+      .pipe(startWith(null), takeUntil(this.destroy$))
+      .subscribe(() => this.applyFilters());
+
+    this.route.queryParamMap
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(params => {
+        const brokerParam = params.get('broker');
+        if (!brokerParam) {
+          return;
+        }
+
+        const normalized = brokerParam.toUpperCase();
+        const target = this.brokerOptions.find(option => option.value === normalized);
+        this.brokerControl.setValue(target ? target.value : 'ALL');
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  toggleRobot(robot: RobotStatus): void {
+    robot.active = !robot.active;
+  }
+
+  formatDurationSince(startedAt: string): string {
+    const start = new Date(startedAt).getTime();
+    const now = Date.now();
+    const diffMs = Math.max(now - start, 0);
+
+    const diffMinutes = Math.floor(diffMs / 60000);
+    const days = Math.floor(diffMinutes / (60 * 24));
+    const hours = Math.floor((diffMinutes % (60 * 24)) / 60);
+    const minutes = diffMinutes % 60;
+
+    const parts: string[] = [];
+    if (days > 0) {
+      parts.push(`${days} j`);
+    }
+    if (hours > 0) {
+      parts.push(`${hours} h`);
+    }
+    if (minutes > 0 || parts.length === 0) {
+      parts.push(`${minutes} min`);
+    }
+
+    return parts.join(' ');
+  }
+
+  getRobotStateLabel(robot: RobotStatus): string {
+    return robot.active ? 'Actif' : 'Inactif';
+  }
+
+  private applyFilters(): void {
+    const brokerFilter = this.brokerControl.value;
+    const timeframeFilter = this.timeframeControl.value;
+
+    this.filteredMarkets = this.markets.filter(market => {
+      const brokerMatches = brokerFilter === 'ALL' || market.broker === brokerFilter;
+      const timeframeMatches = timeframeFilter === 'ALL' || market.timeframe === timeframeFilter;
+      return brokerMatches && timeframeMatches;
+    });
+
+    this.filteredRobots = this.robots.filter(robot => {
+      const brokerMatches = brokerFilter === 'ALL' || robot.broker === brokerFilter;
+      const timeframeMatches = timeframeFilter === 'ALL' || robot.timeframes.includes(timeframeFilter);
+      return brokerMatches && timeframeMatches;
+    });
+  }
+
+  private hoursAgo(hours: number): string {
+    const date = new Date(Date.now() - hours * 60 * 60 * 1000);
+    return date.toISOString();
+  }
+}

--- a/src/app/components/live-data/live-data.component.html
+++ b/src/app/components/live-data/live-data.component.html
@@ -115,28 +115,32 @@
             </select>
           </label>
 
-          <div class="summary-grid">
-            <div class="summary-item">
-              <span class="summary-label">Montant global</span>
-              <span class="summary-value">
-                {{ summaryMetrics.totalPortfolio | number: '1.0-2' }} $
-              </span>
-            </div>
-            <div class="summary-item">
-              <span class="summary-label">Liquidité disponible</span>
-              <span class="summary-value">{{ summaryMetrics.liquidity | number: '1.0-2' }} $</span>
-            </div>
-            <div class="summary-item">
-              <span class="summary-label">Montant des positions</span>
-              <span class="summary-value">{{ summaryMetrics.positionsValue | number: '1.0-2' }} $</span>
-            </div>
-            <div class="summary-item">
-              <span class="summary-label">Positions</span>
-              <span class="summary-value">{{ summaryMetrics.positionsCount }}</span>
-            </div>
-          </div>
+      <div class="summary-grid">
+        <div class="summary-item">
+          <span class="summary-label">Montant global</span>
+          <span class="summary-value">
+            {{ summaryMetrics.totalPortfolio | number: '1.0-2' }} $
+          </span>
         </div>
-      </section>
+        <div class="summary-item">
+          <span class="summary-label">Liquidité disponible</span>
+          <span class="summary-value">{{ summaryMetrics.liquidity | number: '1.0-2' }} $</span>
+        </div>
+        <div class="summary-item">
+          <span class="summary-label">Montant des positions</span>
+          <span class="summary-value">{{ summaryMetrics.positionsValue | number: '1.0-2' }} $</span>
+        </div>
+        <div class="summary-item">
+          <span class="summary-label">Positions</span>
+          <span class="summary-value">{{ summaryMetrics.positionsCount }}</span>
+        </div>
+      </div>
+
+      <button type="button" class="robots-button" (click)="openActiveRobots()">
+        Robots actifs
+      </button>
+    </div>
+  </section>
 
       <section class="broker-status-panel">
         <header>
@@ -202,6 +206,15 @@
       </table>
     </div>
   </section>
+
+  <div class="live-bottom-split">
+    <div class="left">
+      <app-live-signal-chart [signal]="selectedSignal"></app-live-signal-chart>
+    </div>
+    <div class="right">
+      <app-live-signals-table (select)="onSelectSignal($event)"></app-live-signals-table>
+    </div>
+  </div>
 </div>
 
 <div class="snackbar" *ngIf="snackbarVisible">{{ snackbarMessage }}</div>

--- a/src/app/components/live-data/live-data.component.html
+++ b/src/app/components/live-data/live-data.component.html
@@ -207,14 +207,6 @@
     </div>
   </section>
 
-  <div class="live-bottom-split">
-    <div class="left">
-      <app-live-signal-chart [signal]="selectedSignal"></app-live-signal-chart>
-    </div>
-    <div class="right">
-      <app-live-signals-table (select)="onSelectSignal($event)"></app-live-signals-table>
-    </div>
-  </div>
 </div>
 
 <div class="snackbar" *ngIf="snackbarVisible">{{ snackbarMessage }}</div>

--- a/src/app/components/live-data/live-data.component.scss
+++ b/src/app/components/live-data/live-data.component.scss
@@ -40,29 +40,6 @@
   padding: 1.5rem;
 }
 
-.live-bottom-split {
-  display: grid;
-  grid-template-columns: 1fr 420px;
-  gap: 12px;
-  margin-top: 16px;
-}
-
-.live-bottom-split .left,
-.live-bottom-split .right {
-  min-height: 420px;
-}
-
-app-live-signal-chart {
-  display: block;
-  height: 420px;
-}
-
-app-live-signals-table {
-  display: block;
-  height: 420px;
-  overflow: auto;
-}
-
 .chart-card {
   padding: 1rem 1.25rem 1.5rem;
   display: flex;

--- a/src/app/components/live-data/live-data.component.scss
+++ b/src/app/components/live-data/live-data.component.scss
@@ -40,6 +40,29 @@
   padding: 1.5rem;
 }
 
+.live-bottom-split {
+  display: grid;
+  grid-template-columns: 1fr 420px;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.live-bottom-split .left,
+.live-bottom-split .right {
+  min-height: 420px;
+}
+
+app-live-signal-chart {
+  display: block;
+  height: 420px;
+}
+
+app-live-signals-table {
+  display: block;
+  height: 420px;
+  overflow: auto;
+}
+
 .chart-card {
   padding: 1rem 1.25rem 1.5rem;
   display: flex;
@@ -102,6 +125,31 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+}
+
+.robots-button {
+  align-self: flex-start;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(59, 130, 246, 0.9));
+  color: #ffffff;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 0.6rem 1.4rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  box-shadow: 0 12px 20px rgba(37, 99, 235, 0.25);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.robots-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.3);
+}
+
+.robots-button:active {
+  transform: translateY(0);
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.25);
 }
 
 .broker-status-list {

--- a/src/app/components/live-data/live-data.component.ts
+++ b/src/app/components/live-data/live-data.component.ts
@@ -42,10 +42,6 @@ import {
 } from 'chartjs-chart-financial';
 import zoomPlugin from 'chartjs-plugin-zoom';
 import { Router } from '@angular/router';
-import { LiveSignal } from '../../models/live-signal.model';
-import { LiveSignalChartComponent } from '../live-signal-chart/live-signal-chart.component';
-import { LiveSignalsTableComponent } from '../live-signals-table/live-signals-table.component';
-import { LiveSignalsService } from '../../services/live-signals.service';
 
 Chart.register(
   ...registerables,
@@ -115,7 +111,7 @@ interface PortfolioSummary {
 @Component({
   standalone: true,
   selector: 'app-live-data',
-  imports: [CommonModule, ReactiveFormsModule, LiveSignalChartComponent, LiveSignalsTableComponent],
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './live-data.component.html',
   styleUrls: ['./live-data.component.scss']
 })
@@ -138,7 +134,6 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
   snackbarMessage = '';
 
   trades: TradeView[] = [];
-  selectedSignal: LiveSignal | null = null;
   summaryMetrics: PortfolioSummary = {
     totalPortfolio: 0,
     liquidity: 0,
@@ -158,8 +153,7 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
   constructor(
     private readonly fb: NonNullableFormBuilder,
     private readonly marketData: MarketDataService,
-    private readonly router: Router,
-    private readonly liveSignalsService: LiveSignalsService
+    private readonly router: Router
   ) {
     this.summaryBrokerControl = this.fb.control('ALL');
     this.summaryBrokerOptions = [
@@ -187,13 +181,6 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.liveSignalsService.connect();
-    this.liveSignalsService.selected$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(signal => {
-        this.selectedSignal = signal;
-      });
-
     this.startTradesPolling();
     this.summaryBrokerControl.valueChanges
       .pipe(takeUntil(this.destroy$))
@@ -356,12 +343,6 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.snackbarTimeoutHandle) {
       clearTimeout(this.snackbarTimeoutHandle);
     }
-    this.liveSignalsService.disconnect();
-  }
-
-  onSelectSignal(signal: LiveSignal): void {
-    this.selectedSignal = signal;
-    this.liveSignalsService.select(signal);
   }
 
   private startTradesPolling(): void {

--- a/src/app/components/live-data/live-data.component.ts
+++ b/src/app/components/live-data/live-data.component.ts
@@ -41,6 +41,11 @@ import {
   OhlcElement
 } from 'chartjs-chart-financial';
 import zoomPlugin from 'chartjs-plugin-zoom';
+import { Router } from '@angular/router';
+import { LiveSignal } from '../../models/live-signal.model';
+import { LiveSignalChartComponent } from '../live-signal-chart/live-signal-chart.component';
+import { LiveSignalsTableComponent } from '../live-signals-table/live-signals-table.component';
+import { LiveSignalsService } from '../../services/live-signals.service';
 
 Chart.register(
   ...registerables,
@@ -110,7 +115,7 @@ interface PortfolioSummary {
 @Component({
   standalone: true,
   selector: 'app-live-data',
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, LiveSignalChartComponent, LiveSignalsTableComponent],
   templateUrl: './live-data.component.html',
   styleUrls: ['./live-data.component.scss']
 })
@@ -133,6 +138,7 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
   snackbarMessage = '';
 
   trades: TradeView[] = [];
+  selectedSignal: LiveSignal | null = null;
   summaryMetrics: PortfolioSummary = {
     totalPortfolio: 0,
     liquidity: 0,
@@ -151,7 +157,9 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
 
   constructor(
     private readonly fb: NonNullableFormBuilder,
-    private readonly marketData: MarketDataService
+    private readonly marketData: MarketDataService,
+    private readonly router: Router,
+    private readonly liveSignalsService: LiveSignalsService
   ) {
     this.summaryBrokerControl = this.fb.control('ALL');
     this.summaryBrokerOptions = [
@@ -172,7 +180,20 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
     });
   }
 
+  openActiveRobots(): void {
+    const broker = this.summaryBrokerControl.value;
+    const queryParams = broker && broker !== 'ALL' ? { broker } : undefined;
+    this.router.navigate(['/active-robots'], { queryParams });
+  }
+
   ngOnInit(): void {
+    this.liveSignalsService.connect();
+    this.liveSignalsService.selected$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(signal => {
+        this.selectedSignal = signal;
+      });
+
     this.startTradesPolling();
     this.summaryBrokerControl.valueChanges
       .pipe(takeUntil(this.destroy$))
@@ -335,6 +356,12 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.snackbarTimeoutHandle) {
       clearTimeout(this.snackbarTimeoutHandle);
     }
+    this.liveSignalsService.disconnect();
+  }
+
+  onSelectSignal(signal: LiveSignal): void {
+    this.selectedSignal = signal;
+    this.liveSignalsService.select(signal);
   }
 
   private startTradesPolling(): void {

--- a/src/app/components/live-signal-chart/live-signal-chart.component.html
+++ b/src/app/components/live-signal-chart/live-signal-chart.component.html
@@ -1,0 +1,10 @@
+<div class="chart-wrapper">
+  <div class="chart-container" #chartContainer></div>
+  <div class="placeholder" *ngIf="!signal">
+    Sélectionnez un signal pour afficher le graphique.
+  </div>
+  <div class="placeholder" *ngIf="signal && !loading && !hasData">
+    Aucune donnée OHLC disponible pour ce signal.
+  </div>
+  <div class="loading" *ngIf="loading">Chargement…</div>
+</div>

--- a/src/app/components/live-signal-chart/live-signal-chart.component.scss
+++ b/src/app/components/live-signal-chart/live-signal-chart.component.scss
@@ -1,0 +1,40 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.chart-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: #ffffff;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+  overflow: hidden;
+}
+
+.chart-container {
+  position: absolute;
+  inset: 0;
+}
+
+.placeholder,
+.loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  color: #475569;
+  background: rgba(248, 250, 252, 0.88);
+  padding: 1rem;
+  text-align: center;
+}
+
+.loading {
+  font-weight: 600;
+  color: #1d4ed8;
+  background: rgba(219, 234, 254, 0.72);
+}

--- a/src/app/components/live-signal-chart/live-signal-chart.component.ts
+++ b/src/app/components/live-signal-chart/live-signal-chart.component.ts
@@ -1,0 +1,194 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  CandlestickData,
+  IChartApi,
+  ISeriesApi,
+  SeriesMarker,
+  Time,
+  UTCTimestamp,
+  createChart
+} from 'lightweight-charts';
+import { Subscription } from 'rxjs';
+import { MarketDataService } from '../../services/market-data.service';
+import { LiveSignal, OhlcvBar } from '../../models/live-signal.model';
+
+@Component({
+  selector: 'app-live-signal-chart',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './live-signal-chart.component.html',
+  styleUrls: ['./live-signal-chart.component.scss']
+})
+export class LiveSignalChartComponent implements AfterViewInit, OnChanges, OnDestroy {
+  @Input() signal: LiveSignal | null = null;
+  @ViewChild('chartContainer', { static: true }) chartContainer!: ElementRef<HTMLDivElement>;
+
+  loading = false;
+  hasData = false;
+
+  private chart?: IChartApi;
+  private series?: ISeriesApi<'Candlestick'>;
+  private windowSub?: Subscription;
+  private viewInitialized = false;
+
+  constructor(private readonly marketData: MarketDataService) {}
+
+  ngAfterViewInit(): void {
+    this.initializeChart();
+    this.viewInitialized = true;
+    if (this.signal) {
+      this.loadSignal(this.signal);
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!this.viewInitialized) {
+      return;
+    }
+
+    if (changes['signal']) {
+      const currentSignal: LiveSignal | null | undefined = changes['signal'].currentValue;
+      if (currentSignal) {
+        this.loadSignal(currentSignal);
+      } else {
+        this.resetSeries();
+      }
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.windowSub?.unsubscribe();
+    this.chart?.remove();
+  }
+
+  private initializeChart(): void {
+    if (this.chart) {
+      return;
+    }
+
+    const container = this.chartContainer.nativeElement;
+    const { clientWidth } = container;
+
+    this.chart = createChart(container, {
+      width: clientWidth || undefined,
+      height: container.clientHeight || 400,
+      layout: {
+        background: { color: '#ffffff' },
+        textColor: '#0f172a'
+      },
+      grid: {
+        vertLines: { color: '#e2e8f0' },
+        horzLines: { color: '#e2e8f0' }
+      },
+      crosshair: {
+        mode: 0
+      },
+      timeScale: {
+        timeVisible: true,
+        secondsVisible: false
+      }
+    });
+
+    this.series = this.chart.addCandlestickSeries({
+      upColor: '#16a34a',
+      borderUpColor: '#16a34a',
+      wickUpColor: '#16a34a',
+      downColor: '#dc2626',
+      borderDownColor: '#dc2626',
+      wickDownColor: '#dc2626'
+    });
+  }
+
+  private loadSignal(signal: LiveSignal): void {
+    if (!this.series) {
+      return;
+    }
+
+    this.loading = true;
+    this.hasData = false;
+    this.windowSub?.unsubscribe();
+
+    this.windowSub = this.marketData
+      .getWindow({
+        symbol: signal.symbol,
+        timeframe: signal.timeframe,
+        endTsUtc: signal.tsOpenUtc,
+        barsBack: 50,
+        exitTsUtc: signal.payload?.exitTsUtc,
+        maxForward: 120
+      })
+      .subscribe({
+        next: response => {
+          const seriesData = this.transformBars(response.bars);
+          this.series!.setData(seriesData);
+          this.series!.setMarkers(this.buildMarkers(signal));
+          this.hasData = seriesData.length > 0;
+          this.chart?.timeScale().fitContent();
+        },
+        error: error => {
+          console.error('Failed to load signal window', error);
+          this.resetSeries();
+          this.loading = false;
+        },
+        complete: () => {
+          this.loading = false;
+        }
+      });
+  }
+
+  private transformBars(bars: OhlcvBar[]): CandlestickData[] {
+    return bars.map(bar => ({
+      time: (Date.parse(bar.tsUtc) / 1000) as UTCTimestamp,
+      open: bar.open,
+      high: bar.high,
+      low: bar.low,
+      close: bar.close
+    }));
+  }
+
+  private buildMarkers(signal: LiveSignal): SeriesMarker<Time>[] {
+    const markers: SeriesMarker<Time>[] = [];
+    const entryTime = (Date.parse(signal.tsOpenUtc) / 1000) as UTCTimestamp;
+
+    markers.push({
+      time: entryTime,
+      position: signal.side === 'LONG' ? 'belowBar' : 'aboveBar',
+      shape: signal.side === 'LONG' ? 'arrowUp' : 'arrowDown',
+      color: signal.side === 'LONG' ? '#16a34a' : '#dc2626',
+      text: 'ENTRY'
+    });
+
+    const exitTsUtc = signal.payload?.exitTsUtc;
+    if (exitTsUtc) {
+      markers.push({
+        time: (Date.parse(exitTsUtc) / 1000) as UTCTimestamp,
+        position: 'aboveBar',
+        shape: 'circle',
+        color: '#eab308',
+        text: 'EXIT'
+      });
+    }
+
+    return markers;
+  }
+
+  private resetSeries(): void {
+    this.windowSub?.unsubscribe();
+    if (this.series) {
+      this.series.setData([]);
+      this.series.setMarkers([]);
+    }
+    this.hasData = false;
+    this.loading = false;
+  }
+}

--- a/src/app/components/live-signals-table/live-signals-table.component.html
+++ b/src/app/components/live-signals-table/live-signals-table.component.html
@@ -1,0 +1,41 @@
+<div class="signals-table">
+  <table>
+    <thead>
+      <tr>
+        <th>Time (UTC)</th>
+        <th>Symbol</th>
+        <th>TF</th>
+        <th>Side</th>
+        <th>Entry</th>
+        <th>RR</th>
+        <th>SL</th>
+        <th>TP</th>
+        <th>Strategy</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        *ngFor="let signal of signals; trackBy: trackBySignal"
+        (click)="onSelect(signal)"
+        [class.selected]="selectedSignal?.strategyId === signal.strategyId && selectedSignal?.tsOpenUtc === signal.tsOpenUtc"
+      >
+        <td>{{ signal.tsOpenUtc | date: 'yyyy-MM-dd HH:mm:ss':'UTC' }}</td>
+        <td>{{ signal.symbol }}</td>
+        <td>{{ signal.timeframe }}</td>
+        <td>
+          <span class="side" [class.long]="signal.side === 'LONG'" [class.short]="signal.side === 'SHORT'">
+            {{ signal.side }}
+          </span>
+        </td>
+        <td>{{ signal.entryPrice | number: '1.2-5' }}</td>
+        <td>{{ signal.expectedRr !== undefined ? (signal.expectedRr | number: '1.2-2') : '—' }}</td>
+        <td>{{ signal.sl !== undefined ? (signal.sl | number: '1.2-5') : '—' }}</td>
+        <td>{{ signal.tp !== undefined ? (signal.tp | number: '1.2-5') : '—' }}</td>
+        <td>{{ signal.strategyId }}</td>
+      </tr>
+      <tr *ngIf="signals.length === 0">
+        <td colspan="9" class="empty">En attente de signaux…</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/src/app/components/live-signals-table/live-signals-table.component.scss
+++ b/src/app/components/live-signals-table/live-signals-table.component.scss
@@ -1,0 +1,66 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.signals-table {
+  height: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+  background: #ffffff;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+th,
+td {
+  padding: 0.6rem 0.8rem;
+  font-size: 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+tbody tr {
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+tbody tr:hover {
+  background: rgba(219, 234, 254, 0.4);
+}
+
+tbody tr.selected {
+  background: rgba(59, 130, 246, 0.16);
+  transform: translateX(-2px);
+}
+
+.side {
+  font-weight: 600;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  color: #ffffff;
+  display: inline-block;
+}
+
+.side.long {
+  background: #16a34a;
+}
+
+.side.short {
+  background: #dc2626;
+}
+
+.empty {
+  text-align: center;
+  color: #64748b;
+}

--- a/src/app/components/live-signals-table/live-signals-table.component.ts
+++ b/src/app/components/live-signals-table/live-signals-table.component.ts
@@ -1,0 +1,52 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { LiveSignal } from '../../models/live-signal.model';
+import { LiveSignalsService } from '../../services/live-signals.service';
+
+@Component({
+  selector: 'app-live-signals-table',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './live-signals-table.component.html',
+  styleUrls: ['./live-signals-table.component.scss']
+})
+export class LiveSignalsTableComponent implements OnInit, OnDestroy {
+  @Output() select = new EventEmitter<LiveSignal>();
+
+  signals: LiveSignal[] = [];
+  selectedSignal: LiveSignal | null = null;
+
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(private readonly liveSignalsService: LiveSignalsService) {}
+
+  ngOnInit(): void {
+    this.liveSignalsService.signals$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(signals => {
+        this.signals = [...signals].reverse();
+      });
+
+    this.liveSignalsService.selected$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(signal => {
+        this.selectedSignal = signal;
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  onSelect(signal: LiveSignal): void {
+    this.liveSignalsService.select(signal);
+    this.select.emit(signal);
+  }
+
+  trackBySignal(_: number, signal: LiveSignal): string {
+    return `${signal.strategyId}-${signal.symbol}-${signal.timeframe}-${signal.tsOpenUtc}`;
+  }
+}

--- a/src/app/models/live-signal.model.ts
+++ b/src/app/models/live-signal.model.ts
@@ -1,0 +1,29 @@
+export type LiveSignalSide = 'LONG' | 'SHORT';
+
+export interface LiveSignalPayload {
+  exitTsUtc?: string;
+  exitPrice?: number;
+  [key: string]: unknown;
+}
+
+export interface LiveSignal {
+  strategyId: string;
+  symbol: string;
+  timeframe: string;
+  tsOpenUtc: string;
+  side: LiveSignalSide;
+  entryPrice: number;
+  sl?: number;
+  tp?: number;
+  expectedRr?: number;
+  payload?: LiveSignalPayload;
+}
+
+export interface OhlcvBar {
+  tsUtc: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume?: number;
+}

--- a/src/app/services/live-signals.service.ts
+++ b/src/app/services/live-signals.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, NgZone } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { LiveSignal } from '../models/live-signal.model';
+
+const MAX_SIGNAL_BUFFER = 200;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LiveSignalsService {
+  private readonly baseUrl = environment.apiBaseUrl ?? environment.apiUrl ?? '';
+
+  private readonly signalsSubject = new BehaviorSubject<LiveSignal[]>([]);
+  readonly signals$ = this.signalsSubject;
+
+  private readonly selectedSubject = new BehaviorSubject<LiveSignal | null>(null);
+  readonly selected$ = this.selectedSubject.asObservable();
+
+  private eventSource?: EventSource;
+
+  constructor(private readonly zone: NgZone) {}
+
+  connect(path = '/live/stream'): void {
+    if (this.eventSource) {
+      return;
+    }
+
+    const url = this.normalizeUrl(path);
+
+    this.zone.runOutsideAngular(() => {
+      this.eventSource = new EventSource(url);
+
+      this.eventSource.onmessage = (event: MessageEvent) => {
+        try {
+          const payload = JSON.parse(event.data) as LiveSignal;
+          this.zone.run(() => this.pushSignal(payload));
+        } catch (error) {
+          console.error('Failed to parse live signal event', error);
+        }
+      };
+
+      this.eventSource.onerror = (error: Event) => {
+        console.error('Live signal stream error', error);
+      };
+    });
+  }
+
+  disconnect(): void {
+    this.closeStream();
+    this.signalsSubject.next([]);
+    this.selectedSubject.next(null);
+  }
+
+  select(signal: LiveSignal | null): void {
+    this.selectedSubject.next(signal);
+  }
+
+  private pushSignal(signal: LiveSignal): void {
+    const buffer = [...this.signalsSubject.value, signal];
+    if (buffer.length > MAX_SIGNAL_BUFFER) {
+      buffer.splice(0, buffer.length - MAX_SIGNAL_BUFFER);
+    }
+    this.signalsSubject.next(buffer);
+
+    if (!this.selectedSubject.value) {
+      this.selectedSubject.next(signal);
+    }
+  }
+
+  private closeStream(): void {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = undefined;
+    }
+  }
+
+  private normalizeUrl(path: string): string {
+    if (path.startsWith('http://') || path.startsWith('https://')) {
+      return path;
+    }
+    if (this.baseUrl) {
+      return `${this.baseUrl}${path}`;
+    }
+    return path;
+  }
+}

--- a/src/app/services/market-data.service.ts
+++ b/src/app/services/market-data.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { HistBar, StartBarsResponse, TradeView } from '../models/trading.models';
+import { OhlcvBar } from '../models/live-signal.model';
 
 @Injectable({
   providedIn: 'root'
@@ -64,5 +65,32 @@ export class MarketDataService {
   listTrades(broker = 'IBKR'): Observable<TradeView[]> {
     const params = new HttpParams().set('broker', broker);
     return this.http.get<TradeView[]>(`${this.baseUrl}/trades`, { params });
+  }
+
+  getWindow(params: {
+    symbol: string;
+    timeframe: string;
+    endTsUtc: string;
+    barsBack: number;
+    exitTsUtc?: string;
+    maxForward?: number;
+  }): Observable<{ bars: OhlcvBar[] }> {
+    let httpParams = new HttpParams()
+      .set('symbol', params.symbol)
+      .set('timeframe', params.timeframe)
+      .set('endTsUtc', params.endTsUtc)
+      .set('barsBack', String(params.barsBack));
+
+    if (params.exitTsUtc) {
+      httpParams = httpParams.set('exitTsUtc', params.exitTsUtc);
+    }
+
+    if (params.maxForward !== undefined) {
+      httpParams = httpParams.set('maxForward', String(params.maxForward));
+    }
+
+    return this.http.get<{ bars: OhlcvBar[] }>(`${this.baseUrl}/marketdata/ohlcv/window`, {
+      params: httpParams
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add lightweight-charts dependency plus shared live signal models and streaming service
- build live signal chart and real-time signals table components and embed them below the existing live data tables
- document the new live overlay requirements and endpoints in the README

## Testing
- npm run build *(fails: ng not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6905556528d48323934129af48b4d49d