### PR TITLE
Fetch portfolio overview data from backend snapshot

### DIFF
--- a/src/app/components/live-data/live-data.component.ts
+++ b/src/app/components/live-data/live-data.component.ts
@@ -31,6 +31,7 @@ import {
 } from 'rxjs/operators';
 import { MarketDataService } from '../../services/market-data.service';
 import { HistBar, TradeView } from '../../models/trading.models';
+import { PortfolioSnapshot } from '../../models/portfolio.model';
 import { Chart, ChartConfiguration, registerables } from 'chart.js';
 import 'chartjs-chart-financial';
 import 'chartjs-adapter-date-fns';
@@ -144,11 +145,9 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   private charts: Chart<'candlestick'>[] = [];
   private snackbarTimeoutHandle?: ReturnType<typeof setTimeout>;
-  private readonly brokerLiquidity: Record<string, number> = {
-    IBKR: 150_000,
-    MEXC: 60_000
-  };
   private readonly brokerConnectionStatus: Record<string, boolean> = {};
+  private portfolioSnapshots: Record<string, PortfolioSnapshot> = {};
+  private portfolioSnapshotLoading = false;
 
   constructor(
     private readonly fb: NonNullableFormBuilder,
@@ -184,7 +183,10 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
     this.startTradesPolling();
     this.summaryBrokerControl.valueChanges
       .pipe(takeUntil(this.destroy$))
-      .subscribe(() => this.updatePortfolioSummary());
+      .subscribe(() => {
+        this.updatePortfolioSummary();
+        this.refreshPortfolioSnapshots();
+      });
     this.updatePortfolioSummary();
   }
 
@@ -369,6 +371,9 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
       .subscribe(trades => {
         this.trades = trades;
         this.updatePortfolioSummary();
+        if (Object.keys(this.portfolioSnapshots).length === 0) {
+          this.refreshPortfolioSnapshots();
+        }
       });
   }
 
@@ -531,53 +536,7 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private updatePortfolioSummary(): void {
-    const selection = this.summaryBrokerControl.value ?? 'ALL';
-
-    const relevantBrokers =
-      selection === 'ALL'
-        ? this.brokerOptions
-        : this.brokerOptions.includes(selection)
-          ? [selection]
-          : [];
-
-    if (
-      relevantBrokers.length === 0 ||
-      !relevantBrokers.every(broker => this.isBrokerConnected(broker))
-    ) {
-      this.summaryMetrics = {
-        totalPortfolio: 0,
-        liquidity: 0,
-        positionsValue: 0,
-        positionsCount: 0
-      };
-      return;
-    }
-
-    const relevantTrades =
-      selection === 'ALL'
-        ? this.trades
-        : this.trades.filter(trade => trade.broker === selection);
-
-    const liquidity = relevantBrokers.reduce(
-      (total, broker) => total + (this.brokerLiquidity[broker] ?? 0),
-      0
-    );
-
-    const positionsValue = relevantTrades.reduce((total, trade) => {
-      if (typeof trade.marketValue === 'number') {
-        return total + trade.marketValue;
-      }
-      return total + trade.position * trade.avgCost;
-    }, 0);
-
-    const positionsCount = relevantTrades.filter(trade => trade.position !== 0).length;
-
-    this.summaryMetrics = {
-      totalPortfolio: positionsValue + liquidity,
-      liquidity,
-      positionsValue,
-      positionsCount
-    };
+    this.updatePortfolioSummaryFromSnapshots();
   }
 
   isBrokerConnected(broker: string | null | undefined): boolean {
@@ -621,7 +580,124 @@ export class LiveDataComponent implements OnInit, AfterViewInit, OnDestroy {
     this.brokerConnectionStatus[broker] = connected;
     if (!connected) {
       this.trades = [];
+      delete this.portfolioSnapshots[broker];
     }
     this.updatePortfolioSummary();
+    if (connected) {
+      this.refreshPortfolioSnapshots();
+    }
+  }
+
+  private getConnectedBrokers(): string[] {
+    return this.brokerOptions.filter(broker => this.isBrokerConnected(broker));
+  }
+
+  private refreshPortfolioSnapshots(): void {
+    const connectedBrokers = this.getConnectedBrokers();
+
+    if (connectedBrokers.length === 0 || this.portfolioSnapshotLoading) {
+      if (connectedBrokers.length === 0) {
+        this.portfolioSnapshots = {};
+        this.resetSummaryMetrics();
+      }
+      return;
+    }
+
+    this.portfolioSnapshotLoading = true;
+    this.marketData
+      .getPortfolioSnapshots()
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.portfolioSnapshotLoading = false;
+        }),
+        catchError(err => {
+          console.error('Failed to load portfolio snapshots', err);
+          return of<PortfolioSnapshot[]>([]);
+        })
+      )
+      .subscribe(response => {
+        const snapshotsArray = Array.isArray(response) ? response : response ? [response] : [];
+        const snapshotMap: Record<string, PortfolioSnapshot> = {};
+
+        snapshotsArray.forEach(snapshot => {
+          if (snapshot && snapshot.broker && connectedBrokers.includes(snapshot.broker)) {
+            snapshotMap[snapshot.broker] = snapshot;
+          }
+        });
+
+        this.portfolioSnapshots = snapshotMap;
+        this.updatePortfolioSummaryFromSnapshots();
+      });
+  }
+
+  private updatePortfolioSummaryFromSnapshots(): void {
+    const selection = this.summaryBrokerControl.value ?? 'ALL';
+    const connectedBrokers = this.getConnectedBrokers();
+
+    if (connectedBrokers.length === 0) {
+      this.resetSummaryMetrics();
+      return;
+    }
+
+    const relevantBrokers =
+      selection === 'ALL'
+        ? connectedBrokers
+        : connectedBrokers.includes(selection)
+          ? [selection]
+          : [];
+
+    if (relevantBrokers.length === 0) {
+      this.resetSummaryMetrics();
+      return;
+    }
+
+    const snapshots = relevantBrokers
+      .map(broker => this.portfolioSnapshots[broker])
+      .filter((snapshot): snapshot is PortfolioSnapshot => !!snapshot);
+
+    if (snapshots.length === 0) {
+      this.resetSummaryMetrics();
+      return;
+    }
+
+    const totalPortfolio = snapshots.reduce(
+      (total, snapshot) => total + (snapshot.totalMarketValue ?? 0),
+      0
+    );
+
+    const liquidity = snapshots.reduce(
+      (total, snapshot) => total + (snapshot.availableLiquidity ?? 0),
+      0
+    );
+
+    const positionsValue = snapshots.reduce((total, snapshot) => {
+      const brokerPositionsValue = snapshot.positions.reduce(
+        (positionTotal, position) => positionTotal + (position.marketValue ?? 0),
+        0
+      );
+      return total + brokerPositionsValue;
+    }, 0);
+
+    const positionsCount = snapshots.reduce(
+      (total, snapshot) => total + snapshot.positions.length,
+      0
+    );
+
+    this.summaryMetrics = {
+      totalPortfolio,
+      liquidity,
+      positionsValue,
+      positionsCount
+    };
+  }
+
+  private resetSummaryMetrics(): void {
+    this.summaryMetrics = {
+      totalPortfolio: 0,
+      liquidity: 0,
+      positionsValue: 0,
+      positionsCount: 0
+    };
   }
 }

--- a/src/app/models/portfolio.model.ts
+++ b/src/app/models/portfolio.model.ts
@@ -1,0 +1,25 @@
+export interface PortfolioSnapshot {
+  broker: string;
+  totalMarketValue: number;
+  availableLiquidity: number;
+  positions: PortfolioPosition[];
+  asOf: number;
+}
+
+export interface PortfolioPosition {
+  broker: string;
+  account: string;
+  symbol: string;
+  description: string;
+  securityType: string;
+  currency: string;
+  exchange: string;
+  contractId: number | null;
+  position: number;
+  marketPrice: number;
+  marketValue: number;
+  averageCost: number;
+  unrealizedPnL: number;
+  realizedPnL: number;
+  relativeValue: number;
+}

--- a/src/app/services/market-data.service.ts
+++ b/src/app/services/market-data.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { HistBar, StartBarsResponse, TradeView } from '../models/trading.models';
+import { PortfolioSnapshot } from '../models/portfolio.model';
 import { OhlcvBar } from '../models/live-signal.model';
 
 @Injectable({
@@ -65,6 +66,10 @@ export class MarketDataService {
   listTrades(broker = 'IBKR'): Observable<TradeView[]> {
     const params = new HttpParams().set('broker', broker);
     return this.http.get<TradeView[]>(`${this.baseUrl}/trades`, { params });
+  }
+
+  getPortfolioSnapshots(): Observable<PortfolioSnapshot[] | PortfolioSnapshot> {
+    return this.http.get<PortfolioSnapshot[] | PortfolioSnapshot>(`${this.baseUrl}/portfolio`);
   }
 
   getWindow(params: {


### PR DESCRIPTION
## Summary
- add portfolio snapshot model and API call for retrieving portfolio snapshots
- drive the live-data portfolio overview metrics from backend responses when brokers are connected

## Testing
- npx ng build *(fails: npm registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_690672d46afc8323ab2bfbf8428fd4a0