### PR TITLE
feat: add market analysis page with seasonal stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "front-financial-project",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/animations": "^19.2.0",
+        "@angular/cdk": "^19.2.0",
         "@angular/common": "^19.2.0",
         "@angular/compiler": "^19.2.0",
         "@angular/core": "^19.2.0",
         "@angular/forms": "^19.2.0",
+        "@angular/material": "^19.2.0",
         "@angular/platform-browser": "^19.2.0",
         "@angular/platform-browser-dynamic": "^19.2.0",
         "@angular/router": "^19.2.0",
@@ -21,6 +24,7 @@
         "chartjs-plugin-annotation": "^3.1.0",
         "chartjs-plugin-zoom": "^2.2.0",
         "date-fns": "^4.1.0",
+        "lightweight-charts": "^4.2.1",
         "ng2-charts": "^4.1.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -311,6 +315,20 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@angular/animations": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.2.0.tgz",
+      "integrity": "sha512-GJDwtZ+7XmAAbzCbPSJrR1iMs2l16VoA7myeVl6n5k/KsZywqb4KhPmjzLKpQlAFP0NRjg1LbHc2Fsus7/Ydag==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "19.2.0"
       }
     },
     "node_modules/@angular/build": {
@@ -938,11 +956,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.1.tgz",
-      "integrity": "sha512-j7dg18PJIbyeU4DTko3vIK3M2OuUv3H0ZViNddOaLlGN5X93cq4QCGcNhcGm3x3r5rUr/AaexYu+KHMyN8PwmA==",
-      "license": "MIT",
-      "peer": true,
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.0.tgz",
+      "integrity": "sha512-FZQtXszPnqUdFFXa+fBCl1NdFvcWvEyQH0O0tlXhc9ZNBvAofKnn1kU1pMQ4krjqRCguyN1oh6M7rA8Ft92yuA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1085,6 +1101,22 @@
         "@angular/common": "19.2.0",
         "@angular/core": "19.2.0",
         "@angular/platform-browser": "19.2.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.2.0.tgz",
+      "integrity": "sha512-lfIIM2BjWPjTjF+ZBf0yM6F2NRtiARhiVrunjM6j43wF+nXq/R/f/mbxBZVbammilBTvfJtw4EBveuLy/65a6Q==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "19.2.0",
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
+        "@angular/forms": "^19.0.0 || ^20.0.0",
+        "@angular/platform-browser": "^19.0.0 || ^20.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -8148,6 +8180,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10088,6 +10125,14 @@
         "webpack-sources": {
           "optional": true
         }
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.2.3.tgz",
+      "integrity": "sha512-5kS/2hY3wNYNzhnS8Gb+GAS07DX8GPF2YVDnd2NMC85gJVQ6RLU6YrXNgNJ6eg0AnWPwCnvaGtYmGky3HiLQEw==",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
       }
     },
     "node_modules/lines-and-columns": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,13 @@
   },
   "private": true,
   "dependencies": {
+    "@angular/animations": "^19.2.0",
+    "@angular/cdk": "^19.2.0",
     "@angular/common": "^19.2.0",
     "@angular/compiler": "^19.2.0",
     "@angular/core": "^19.2.0",
     "@angular/forms": "^19.2.0",
+    "@angular/material": "^19.2.0",
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,6 +9,7 @@
         <a routerLink="/strategy-calculation">Calcul strats</a>
         <a routerLink="/screen-strategies">Strategies</a>
         <a routerLink="/live-data">Live Data</a>
+        <a routerLink="/market-analysis">Market Stats & Saisonnalities</a>
       </nav>
     </div>
     <router-outlet />

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,8 +1,15 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideHttpClient(),
+    provideAnimations()
+  ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import {ScreenStrategiesComponent} from './components/screen-strategies/screen-s
 import {StrategyDetailComponent} from './components/strategy-detail/strategy-detail.component';
 import {LiveDataComponent} from './components/live-data/live-data.component'; // 🆕
 import {ActiveRobotsComponent} from './components/active-robots/active-robots.component';
+import { MarketAnalysisPage } from './components/market-analysis/market-analysis.page';
 
 export const routes: Routes = [
   { path: 'historical-data', component: HistoricalDataComponent },
@@ -15,6 +16,7 @@ export const routes: Routes = [
   { path: 'strategy-detail/:name/:runId/:symbol/:comparedSymbol', component: StrategyDetailComponent },
   { path: 'live-data', component: LiveDataComponent },
   { path: 'active-robots', component: ActiveRobotsComponent },
+  { path: 'market-analysis', component: MarketAnalysisPage },
   {
     path: '_lab/signals',
     loadChildren: () => import('./labs/signals/signals.routes').then(m => m.SIGNALS_ROUTES)

--- a/src/app/components/market-analysis/market-analysis.page.html
+++ b/src/app/components/market-analysis/market-analysis.page.html
@@ -1,5 +1,7 @@
 <section class="market-analysis">
   <header class="market-analysis__header">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
     <form [formGroup]="analysisForm" class="analysis-form" (ngSubmit)="loadAnalysis()">
       <mat-form-field appearance="outline">
         <mat-label>Symbole</mat-label>

--- a/src/app/components/market-analysis/market-analysis.page.html
+++ b/src/app/components/market-analysis/market-analysis.page.html
@@ -1,0 +1,197 @@
+<section class="market-analysis">
+  <header class="market-analysis__header">
+    <form [formGroup]="analysisForm" class="analysis-form" (ngSubmit)="loadAnalysis()">
+      <mat-form-field appearance="outline">
+        <mat-label>Symbole</mat-label>
+        <mat-select formControlName="symbol">
+          <mat-option value="EURUSD">EURUSD (Forex)</mat-option>
+          <mat-option value="GBPUSD">GBPUSD (Forex)</mat-option>
+          <mat-option value="BTCUSD">BTCUSD (Crypto)</mat-option>
+          <mat-option value="ETHUSD">ETHUSD (Crypto)</mat-option>
+          <mat-option value="AAPL">AAPL (Actions)</mat-option>
+          <mat-option value="MSFT">MSFT (Actions)</mat-option>
+          <mat-option value="SPY">SPY (ETF)</mat-option>
+          <mat-option value="EEM">EEM (ETF)</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Timeframe</mat-label>
+        <mat-select formControlName="timeframe">
+          <mat-option value="15m">15m</mat-option>
+          <mat-option value="1h">1h</mat-option>
+          <mat-option value="4h">4h</mat-option>
+          <mat-option value="1d">1D</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Timeframes comparaison</mat-label>
+        <input matInput formControlName="timeframesCsv" placeholder="15m,1h,4h" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Nombre de bougies</mat-label>
+        <input matInput type="number" formControlName="range" />
+      </mat-form-field>
+
+      <button mat-flat-button color="primary" type="submit" [disabled]="loading()">
+        <mat-icon>auto_graph</mat-icon>
+        Analyser
+      </button>
+    </form>
+    <mat-progress-bar *ngIf="loading()" mode="indeterminate"></mat-progress-bar>
+  </header>
+
+  <section class="kpis" *ngIf="kpis() as summary">
+    <mat-card class="kpi-card" *ngFor="let item of [
+      { label: 'ATR %', value: summary.atrPercent, suffix: '%' },
+      { label: 'Range moyen', value: summary.averageRange },
+      { label: 'Skewness', value: summary.skewness },
+      { label: 'Kurtosis', value: summary.kurtosis },
+      { label: 'Max DD', value: summary.maxDrawdown, suffix: '%' }
+    ]">
+      <mat-card-header>
+        <mat-card-title>{{ item.label }}</mat-card-title>
+        <mat-chip *ngIf="candlesMock()" class="mock-chip" appearance="outlined">mock</mat-chip>
+      </mat-card-header>
+      <mat-card-content>
+        <span class="kpi-value">{{ item.value | number:'1.0-2' }}{{ item.suffix ?? '' }}</span>
+      </mat-card-content>
+    </mat-card>
+  </section>
+
+  <mat-card class="content-card">
+    <mat-tab-group>
+      <mat-tab label="Saisonnalité">
+        <div class="tab-header">
+          <h3>Saisonnalité mensuelle & hebdomadaire</h3>
+          <mat-chip *ngIf="seasonalityMock()" class="mock-chip" appearance="outlined">mock</mat-chip>
+        </div>
+        <div class="seasonality-charts">
+          @let monthConfig = monthChartConfig();
+          @let dowConfig = dowChartConfig();
+          <div class="chart">
+            <canvas
+              baseChart
+              [data]="monthConfig.data"
+              [options]="monthConfig.options"
+              [type]="monthConfig.type"
+            ></canvas>
+          </div>
+          <div class="chart">
+            <canvas
+              baseChart
+              [data]="dowConfig.data"
+              [options]="dowConfig.options"
+              [type]="dowConfig.type"
+            ></canvas>
+          </div>
+        </div>
+        <mat-divider></mat-divider>
+        <div class="heatmap-container">
+          <div class="tab-header">
+            <h3>Heatmap horaire</h3>
+          </div>
+          @let heatmapConfig = heatmapChartConfig();
+          <div class="heatmap-chart">
+            <canvas
+              baseChart
+              [data]="heatmapConfig.data"
+              [options]="heatmapConfig.options"
+              [type]="heatmapConfig.type"
+            ></canvas>
+          </div>
+        </div>
+      </mat-tab>
+      <mat-tab label="Patterns & Probabilités">
+        <div class="tab-header">
+          <h3>Statistiques d'événements</h3>
+          <mat-chip *ngIf="statsMock()" class="mock-chip" appearance="outlined">mock</mat-chip>
+        </div>
+        <div class="stats-table-wrapper" *ngIf="statsSummary().length; else statsEmpty">
+          <table class="stats-table">
+            <thead>
+              <tr>
+                <th>Événement</th>
+                <th>Cible</th>
+                <th>N</th>
+                <th>p̂</th>
+                <th>IC bas</th>
+                <th>IC haut</th>
+                <th>Lift</th>
+                <th>q-value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let row of statsSummary(); trackBy: trackStat">
+                <td>{{ row.event }}</td>
+                <td>{{ row.target }}</td>
+                <td>{{ row.n | number }}</td>
+                <td>{{ row.pHat | number:'1.2-2' }}</td>
+                <td>{{ row.ciLow | number:'1.2-2' }}</td>
+                <td>{{ row.ciHigh | number:'1.2-2' }}</td>
+                <td>{{ (row.lift ?? 0) | number:'1.2-2' }}</td>
+                <td>
+                  @if (row.qValue !== undefined) {
+                    {{ row.qValue | number:'1.2-2' }}
+                  } @else {
+                    -
+                  }
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <ng-template #statsEmpty>
+          <p class="empty-state">Aucune statistique disponible pour ce filtre.</p>
+        </ng-template>
+      </mat-tab>
+      <mat-tab label="Filtres">
+        <div class="tab-header">
+          <h3>Filtres actifs</h3>
+          <mat-chip *ngIf="filters().isMock" class="mock-chip" appearance="outlined">mock</mat-chip>
+        </div>
+        <div class="filters-grid" *ngIf="filters().cards.length; else filtersEmpty">
+          <mat-card class="filter-card" *ngFor="let card of filters().cards; trackBy: trackFilter">
+            <mat-card-header>
+              <mat-card-title>{{ card.title }}</mat-card-title>
+              <mat-chip class="source-chip" [ngClass]="card.source.toLowerCase()">
+                {{ card.source === 'JAVA' ? '🟪 JAVA' : '🔵 PY' }}
+              </mat-chip>
+            </mat-card-header>
+            <mat-card-content>
+              <p class="filter-category">{{ card.category }}</p>
+              <p class="filter-description" *ngIf="card.description">{{ card.description }}</p>
+              <div class="filter-metrics">
+                <div class="metric" *ngIf="card.score as score">
+                  <span>Score</span>
+                  <mat-progress-bar mode="determinate" [value]="score * 100"></mat-progress-bar>
+                  <strong>{{ score | number:'1.2-2' }}</strong>
+                </div>
+                <div class="metric" *ngIf="card.ratio as ratio">
+                  <span>Ratio</span>
+                  <mat-progress-bar mode="determinate" [value]="ratio * 100"></mat-progress-bar>
+                  <strong>{{ ratio | percent:'1.0-1' }}</strong>
+                </div>
+                <div class="metric" *ngFor="let metric of card.metrics | keyvalue">
+                  <span>{{ metric.key }}</span>
+                  <strong>{{ metric.value }}</strong>
+                </div>
+              </div>
+              <div class="sparkline" *ngIf="card.series?.length">
+                @let path = filterSparklines().get(card.id);
+                <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+                  <path [attr.d]="path" />
+                </svg>
+              </div>
+            </mat-card-content>
+          </mat-card>
+        </div>
+        <ng-template #filtersEmpty>
+          <p class="empty-state">Aucun filtre disponible.</p>
+        </ng-template>
+      </mat-tab>
+    </mat-tab-group>
+  </mat-card>
+</section>

--- a/src/app/components/market-analysis/market-analysis.page.scss
+++ b/src/app/components/market-analysis/market-analysis.page.scss
@@ -1,0 +1,180 @@
+.market-analysis {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+}
+
+.market-analysis__header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--mat-sys-surface, #121212);
+  padding: 1rem 1.5rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.analysis-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1rem;
+  align-items: end;
+}
+
+.analysis-form button {
+  height: 56px;
+  align-self: stretch;
+}
+
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.kpi-card {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(59, 130, 246, 0.12));
+}
+
+.kpi-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--mat-sys-on-surface, #f8fafc);
+}
+
+.content-card {
+  padding: 1.5rem;
+}
+
+.tab-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.mock-chip {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.seasonality-charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.chart,
+.heatmap-chart {
+  min-height: 260px;
+}
+
+.heatmap-container {
+  margin-top: 1.5rem;
+}
+
+.stats-table-wrapper {
+  overflow-x: auto;
+}
+
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.stats-table th,
+.stats-table td {
+  text-align: left;
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.empty-state {
+  color: rgba(226, 232, 240, 0.7);
+  font-style: italic;
+}
+
+.filters-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.filter-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.filter-category {
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.85);
+  margin-bottom: 0.5rem;
+}
+
+.filter-description {
+  margin-bottom: 0.75rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.filter-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.metric span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.metric strong {
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.sparkline {
+  height: 60px;
+}
+
+.sparkline svg {
+  width: 100%;
+  height: 100%;
+}
+
+.sparkline path {
+  fill: none;
+  stroke: #22d3ee;
+  stroke-width: 2;
+}
+
+.source-chip.java {
+  background-color: rgba(124, 58, 237, 0.2);
+  color: #c4b5fd;
+}
+
+.source-chip.py {
+  background-color: rgba(37, 99, 235, 0.2);
+  color: #bfdbfe;
+}
+
+@media (max-width: 768px) {
+  .market-analysis {
+    padding: 1rem;
+  }
+
+  .market-analysis__header {
+    top: -1px;
+  }
+
+  .analysis-form {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  }
+}

--- a/src/app/components/market-analysis/market-analysis.page.scss
+++ b/src/app/components/market-analysis/market-analysis.page.scss
@@ -1,35 +1,97 @@
-.market-analysis {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  padding: 1.5rem;
-}
-
+/* --- HEADER centré avec style arrondi --- */
 .market-analysis__header {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background: var(--mat-sys-surface, #121212);
-  padding: 1rem 1.5rem;
-  border-radius: 0.75rem;
-  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.25);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+
+  background: #ffffff;
+  border-radius: 16px; /* coins arrondis */
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+  padding: 2rem 3rem 1.75rem;
 }
 
-.analysis-form {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 1rem;
-  align-items: end;
+/* --- FORMULAIRE --- */
+.market-analysis__header .analysis-form {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem 2rem;
+  align-items: flex-end;
+  width: 100%;
+  max-width: 1200px; /* limite la largeur */
 }
 
-.analysis-form button {
+/* --- CHAMPS --- */
+.market-analysis__header mat-form-field {
+  min-width: 200px;
+  flex: 1;
+  font-size: 1.05rem;
+}
+
+.market-analysis__header mat-label,
+.market-analysis__header .mat-mdc-select-value,
+.market-analysis__header .mat-mdc-input-element {
+  font-size: 1rem !important;
+}
+
+/* --- LISTE DÉROULANTE opaque + taille lisible --- */
+.mat-mdc-select-panel {
+  background: #ffffff !important;
+  color: #111827 !important;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25) !important;
+  border-radius: 10px !important; /* arrondi du menu déroulant */
+  font-size: 1rem !important;
+}
+
+.mat-mdc-option .mdc-list-item__primary-text {
+  color: #111827 !important;
+  font-size: 1rem !important;
+}
+
+/* Survol option */
+.mat-mdc-option.mdc-list-item--selected,
+.mat-mdc-option.mdc-list-item--activated,
+.mat-mdc-option:hover {
+  background: rgba(99, 102, 241, 0.1) !important;
+}
+
+/* --- BOUTON --- */
+.market-analysis__header button[mat-flat-button] {
+  background-color: #6366f1;
+  color: #ffffff;
   height: 56px;
-  align-self: stretch;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 10px; /* bouton arrondi */
+  font-size: 1.05rem;
+  padding: 0 1.5rem;
 }
 
+/* --- Progress bar --- */
+.market-analysis__header mat-progress-bar {
+  margin-top: 0.75rem;
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+  .market-analysis__header {
+    padding: 1.5rem;
+  }
+
+  .market-analysis__header .analysis-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .market-analysis__header mat-form-field {
+    width: 100%;
+  }
+}
+
+/* KPIs */
 .kpis {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -37,15 +99,20 @@
 }
 
 .kpi-card {
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(59, 130, 246, 0.12));
+  background: linear-gradient(
+      135deg,
+      rgba(99, 102, 241, 0.06),
+      rgba(59, 130, 246, 0.06)
+  );
 }
 
 .kpi-value {
   font-size: 1.75rem;
   font-weight: 700;
-  color: var(--mat-sys-on-surface, #f8fafc);
+  color: #111827;
 }
 
+/* Contenu principal */
 .content-card {
   padding: 1.5rem;
 }
@@ -96,10 +163,11 @@
 }
 
 .empty-state {
-  color: rgba(226, 232, 240, 0.7);
+  color: rgba(75, 85, 99, 0.9);
   font-style: italic;
 }
 
+/* Filtres */
 .filters-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -114,13 +182,13 @@
 
 .filter-category {
   font-weight: 600;
-  color: rgba(226, 232, 240, 0.85);
+  color: #111827;
   margin-bottom: 0.5rem;
 }
 
 .filter-description {
   margin-bottom: 0.75rem;
-  color: rgba(226, 232, 240, 0.75);
+  color: #4b5563;
 }
 
 .filter-metrics {
@@ -132,7 +200,7 @@
 .metric span {
   font-size: 0.75rem;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.85);
+  color: #9ca3af;
 }
 
 .metric strong {
@@ -151,30 +219,18 @@
 
 .sparkline path {
   fill: none;
-  stroke: #22d3ee;
+  stroke: #2563eb;
   stroke-width: 2;
 }
 
 .source-chip.java {
-  background-color: rgba(124, 58, 237, 0.2);
-  color: #c4b5fd;
+  background-color: rgba(124, 58, 237, 0.1);
+  color: #6d28d9;
 }
 
 .source-chip.py {
-  background-color: rgba(37, 99, 235, 0.2);
-  color: #bfdbfe;
+  background-color: rgba(37, 99, 235, 0.1);
+  color: #2563eb;
 }
 
-@media (max-width: 768px) {
-  .market-analysis {
-    padding: 1rem;
-  }
 
-  .market-analysis__header {
-    top: -1px;
-  }
-
-  .analysis-form {
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  }
-}

--- a/src/app/components/market-analysis/market-analysis.page.ts
+++ b/src/app/components/market-analysis/market-analysis.page.ts
@@ -1,0 +1,380 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  effect,
+  inject,
+  signal
+} from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTabsModule } from '@angular/material/tabs';
+import {
+  BarController,
+  BarElement,
+  CategoryScale,
+  Chart,
+  ChartConfiguration,
+  Legend,
+  LinearScale,
+  PointElement,
+  ScatterController,
+  Tooltip
+} from 'chart.js';
+import { BaseChartDirective, NgChartsModule } from 'ng2-charts';
+import { forkJoin } from 'rxjs';
+
+import {
+  Candle,
+  FilterCard,
+  FilterSeriesPoint,
+  HeatmapCell,
+  KpiSummary,
+  SeasonalityProfile,
+  StatsSummaryRow
+} from '../../models/market-analysis.models';
+import { FiltersService } from '../../services/filters.service';
+import { MarketStatsService } from '../../services/market-stats.service';
+
+Chart.register(CategoryScale, LinearScale, BarController, BarElement, Tooltip, Legend, PointElement, ScatterController);
+
+type HeatmapPoint = { x: number; y: number; value: number };
+
+type FilterAggregate = {
+  cards: FilterCard[];
+  isMock: boolean;
+};
+
+@Component({
+  selector: 'app-market-analysis-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatCardModule,
+    MatTabsModule,
+    MatSelectModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatChipsModule,
+    MatSnackBarModule,
+    MatProgressBarModule,
+    MatDividerModule,
+    NgChartsModule,
+    BaseChartDirective
+  ],
+  templateUrl: './market-analysis.page.html',
+  styleUrls: ['./market-analysis.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MarketAnalysisPage {
+  private readonly marketStatsService = inject(MarketStatsService);
+  private readonly filtersService = inject(FiltersService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly analysisForm = this.fb.group({
+    symbol: ['EURUSD', [Validators.required]],
+    venue: ['FX'],
+    timeframe: ['1h', [Validators.required]],
+    range: [400, [Validators.min(50), Validators.max(1000)]],
+    timeframesCsv: ['15m,1h,4h']
+  });
+
+  readonly loading = signal(false);
+
+  readonly candles = signal<Candle[]>([]);
+  readonly candlesMock = signal(false);
+
+  readonly kpis = signal<KpiSummary | null>(null);
+  readonly seasonality = signal<SeasonalityProfile | null>(null);
+  readonly seasonalityMock = signal(false);
+
+  readonly statsSummary = signal<StatsSummaryRow[]>([]);
+  readonly statsMock = signal(false);
+
+  readonly filters = signal<FilterAggregate>({ cards: [], isMock: false });
+  readonly filterSparklines = computed(() => {
+    const map = new Map<string, string>();
+    for (const card of this.filters().cards) {
+      if (card.series?.length) {
+        map.set(card.id, buildSparklinePath(card.series));
+      }
+    }
+    return map;
+  });
+
+  readonly monthChartConfig = computed<ChartConfiguration<'bar'>>(() => {
+    const profile = this.seasonality();
+    return {
+      type: 'bar',
+      data: {
+        labels: profile?.byMonth.map(bar => bar.label) ?? [],
+        datasets: [
+          {
+            label: 'Performance (%)',
+            data: profile?.byMonth.map(bar => bar.value) ?? [],
+            backgroundColor: '#6366f1'
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } }
+      }
+    } satisfies ChartConfiguration<'bar'>;
+  });
+
+  readonly dowChartConfig = computed<ChartConfiguration<'bar'>>(() => {
+    const profile = this.seasonality();
+    return {
+      type: 'bar',
+      data: {
+        labels: profile?.byDow.map(bar => bar.label) ?? [],
+        datasets: [
+          {
+            label: 'Performance (%)',
+            data: profile?.byDow.map(bar => bar.value) ?? [],
+            backgroundColor: '#22d3ee'
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } }
+      }
+    } satisfies ChartConfiguration<'bar'>;
+  });
+
+  readonly heatmapChartConfig = computed<ChartConfiguration<'scatter', HeatmapPoint[], number>>(() => {
+    const profile = this.seasonality();
+    const dataPoints: HeatmapPoint[] = profile?.byHour.map((cell: HeatmapCell) => ({
+      x: cell.hour,
+      y: cell.dow,
+      value: cell.value
+    })) ?? [];
+
+    const dowLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+    return {
+      type: 'scatter',
+      data: {
+        datasets: [
+          {
+            label: 'Hourly Heatmap',
+            data: dataPoints,
+            pointRadius: 18,
+            pointHoverRadius: 18,
+            pointBackgroundColor: ctx => heatmapColor((ctx.raw as HeatmapPoint).value),
+            pointStyle: 'rectRounded',
+            borderWidth: 0
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label(context) {
+                const raw = context.raw as HeatmapPoint;
+                return `D${raw.y + 1} H${raw.x}: ${raw.value.toFixed(0)}%`;
+              }
+            }
+          }
+        },
+        scales: {
+          x: {
+            beginAtZero: true,
+            suggestedMin: -0.5,
+            suggestedMax: 23.5,
+            ticks: {
+              callback: value => `${value}h`
+            }
+          },
+          y: {
+            beginAtZero: true,
+            suggestedMin: -0.5,
+            suggestedMax: 6.5,
+            ticks: {
+              callback: value => dowLabels[Number(value)] ?? ''
+            }
+          }
+        }
+      }
+    } satisfies ChartConfiguration<'scatter', HeatmapPoint[], number>;
+  });
+
+  constructor() {
+    effect(() => {
+      if (!this.loading()) {
+        this.kpis.set(this.marketStatsService.computeKpisFromCandles(this.candles()));
+      }
+    });
+
+    this.loadAnalysis();
+  }
+
+  loadAnalysis(): void {
+    if (this.analysisForm.invalid) {
+      this.snackBar.open('Veuillez renseigner un symbole et un timeframe valides.', 'Fermer', {
+        duration: 3000
+      });
+      return;
+    }
+
+    const { symbol, timeframe, timeframesCsv, range } = this.analysisForm.getRawValue();
+    const parsedSymbol = symbol ?? 'EURUSD';
+    const parsedTimeframe = timeframe ?? '1h';
+    const parsedMulti = timeframesCsv ?? '15m,1h,4h';
+    const startIso = computeStartDate(range ?? 0, parsedTimeframe);
+
+    this.loading.set(true);
+
+    forkJoin({
+      candles: this.marketStatsService.getCandles(parsedSymbol, parsedTimeframe, startIso),
+      seasonality: this.marketStatsService.getSeasonality(parsedSymbol, parsedTimeframe),
+      stats: this.marketStatsService.getStatsSummary({ symbol: parsedSymbol, timeframe: parsedTimeframe }),
+      multi: this.filtersService.getMultiTFStats(parsedSymbol, parsedMulti),
+      benford: this.filtersService.getBenford(parsedSymbol, parsedTimeframe),
+      liquidity: this.filtersService.getGenericFilter<FilterCard[]>(
+        'liquidity',
+        { symbol: parsedSymbol, timeframe: parsedTimeframe }
+      )
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: result => {
+          this.candles.set(result.candles.data);
+          this.candlesMock.set(result.candles.isMock);
+          this.seasonality.set(result.seasonality.data);
+          this.seasonalityMock.set(result.seasonality.isMock);
+          this.statsSummary.set(result.stats.data);
+          this.statsMock.set(result.stats.isMock);
+
+          const combinedFilters = [
+            result.benford.data,
+            ...result.multi.data,
+            ...(Array.isArray(result.liquidity.data) ? result.liquidity.data : [])
+          ].filter((card): card is FilterCard => Boolean(card?.id));
+
+          this.filters.set({
+            cards: combinedFilters,
+            isMock: result.multi.isMock || result.benford.isMock || result.liquidity.isMock
+          });
+
+          this.loading.set(false);
+
+          if (result.candles.isMock) {
+            this.notifyMock('Bougies (candles)');
+          }
+          if (result.seasonality.isMock) {
+            this.notifyMock('Saisonnalité');
+          }
+          if (result.stats.isMock) {
+            this.notifyMock('Patterns & Probabilités');
+          }
+          if (this.filters().isMock) {
+            this.notifyMock('Filtres');
+          }
+        },
+        error: error => {
+          console.error('Market analysis loading failed', error);
+          this.loading.set(false);
+          this.snackBar.open('Analyse indisponible pour le moment. Mocks chargés.', 'Fermer', {
+            duration: 4000
+          });
+        }
+      });
+  }
+
+  trackFilter(_index: number, card: FilterCard): string {
+    return card.id;
+  }
+
+  trackStat(_index: number, row: StatsSummaryRow): string {
+    return `${row.event}-${row.target}`;
+  }
+
+  private notifyMock(section: string): void {
+    this.snackBar.open(`${section} alimenté avec les données mock.`, 'OK', {
+      duration: 2500
+    });
+  }
+}
+
+function heatmapColor(value: number): string {
+  const min = 0;
+  const max = 100;
+  const ratio = Math.max(0, Math.min(1, (value - min) / (max - min)));
+  const hue = (1 - ratio) * 220;
+  return `hsl(${hue}, 85%, 55%)`;
+}
+
+function buildSparklinePath(series: FilterSeriesPoint[]): string {
+  if (!series.length) {
+    return '';
+  }
+
+  const values = series.map(point => point.v);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const lastIndex = series.length - 1 || 1;
+
+  return series
+    .map((point, index) => {
+      const x = (index / lastIndex) * 100;
+      const y = 100 - ((point.v - min) / range) * 100;
+      const command = index === 0 ? 'M' : 'L';
+      return `${command}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+}
+
+function computeStartDate(range: number, timeframe: string): string | undefined {
+  if (!range || range <= 0) {
+    return undefined;
+  }
+  const interval = timeframeToMs(timeframe);
+  if (!interval) {
+    return undefined;
+  }
+
+  const start = new Date(Date.now() - range * interval);
+  return start.toISOString();
+}
+
+function timeframeToMs(timeframe: string): number | undefined {
+  switch (timeframe) {
+    case '15m':
+      return 15 * 60 * 1000;
+    case '1h':
+      return 60 * 60 * 1000;
+    case '4h':
+      return 4 * 60 * 60 * 1000;
+    case '1d':
+      return 24 * 60 * 60 * 1000;
+    default:
+      return undefined;
+  }
+}

--- a/src/app/components/market-analysis/market-analysis.page.ts
+++ b/src/app/components/market-analysis/market-analysis.page.ts
@@ -33,7 +33,7 @@ import {
   ScatterController,
   Tooltip
 } from 'chart.js';
-import { BaseChartDirective, NgChartsModule } from 'ng2-charts';
+import { NgChartsModule } from 'ng2-charts';
 import { forkJoin } from 'rxjs';
 
 import {
@@ -74,8 +74,7 @@ type FilterAggregate = {
     MatSnackBarModule,
     MatProgressBarModule,
     MatDividerModule,
-    NgChartsModule,
-    BaseChartDirective
+    NgChartsModule
   ],
   templateUrl: './market-analysis.page.html',
   styleUrls: ['./market-analysis.page.scss'],
@@ -182,7 +181,10 @@ export class MarketAnalysisPage {
             data: dataPoints,
             pointRadius: 18,
             pointHoverRadius: 18,
-            pointBackgroundColor: ctx => heatmapColor((ctx.raw as HeatmapPoint).value),
+            pointBackgroundColor: ctx => {
+              const raw = ctx.raw as HeatmapPoint | undefined;
+              return heatmapColor(raw?.value ?? 0);
+            },
             pointStyle: 'rectRounded',
             borderWidth: 0
           }
@@ -271,15 +273,41 @@ export class MarketAnalysisPage {
           this.statsSummary.set(result.stats.data);
           this.statsMock.set(result.stats.isMock);
 
+          const multiCards = Array.isArray(result.multi.data)
+            ? result.multi.data
+            : result.multi.data
+              ? [result.multi.data as FilterCard]
+              : [];
+
+          const liquidityCards = Array.isArray(result.liquidity.data)
+            ? result.liquidity.data
+            : result.liquidity.data
+              ? [result.liquidity.data as unknown as FilterCard]
+              : [];
+
           const combinedFilters = [
             result.benford.data,
-            ...result.multi.data,
-            ...(Array.isArray(result.liquidity.data) ? result.liquidity.data : [])
-          ].filter((card): card is FilterCard => Boolean(card?.id));
+            ...multiCards,
+            ...liquidityCards
+          ].filter(
+            (card): card is FilterCard =>
+              !!card && typeof card.id === 'string' && card.id.length > 0
+          );
 
           this.filters.set({
             cards: combinedFilters,
-            isMock: result.multi.isMock || result.benford.isMock || result.liquidity.isMock
+            isMock:
+              result.multi.isMock ||
+              result.benford.isMock ||
+              result.liquidity.isMock
+          });
+
+          this.filters.set({
+            cards: combinedFilters,
+            isMock:
+              result.multi.isMock ||
+              result.benford.isMock ||
+              result.liquidity.isMock
           });
 
           this.loading.set(false);

--- a/src/app/mocks/market-mocks.ts
+++ b/src/app/mocks/market-mocks.ts
@@ -1,0 +1,219 @@
+import { Candle, FilterCard, FilterSeriesPoint, SeasonalityBar, SeasonalityProfile, StatsSummaryRow } from '../models/market-analysis.models';
+
+type SymbolKey = 'EURUSD' | 'GBPUSD' | 'BTCUSD' | 'ETHUSD' | 'AAPL' | 'MSFT' | 'SPY' | 'EEM';
+
+type Timeframe = '15m' | '1h' | '4h' | '1d';
+
+interface SymbolConfig {
+  basePrice: number;
+  volatility: number;
+  timeframe: Timeframe;
+}
+
+const SYMBOL_CONFIG: Record<SymbolKey, SymbolConfig> = {
+  EURUSD: { basePrice: 1.08, volatility: 0.002, timeframe: '1h' },
+  GBPUSD: { basePrice: 1.26, volatility: 0.0025, timeframe: '1h' },
+  BTCUSD: { basePrice: 46000, volatility: 420, timeframe: '1h' },
+  ETHUSD: { basePrice: 3200, volatility: 38, timeframe: '1h' },
+  AAPL: { basePrice: 185, volatility: 3.4, timeframe: '1d' },
+  MSFT: { basePrice: 415, volatility: 4.1, timeframe: '1d' },
+  SPY: { basePrice: 510, volatility: 2.1, timeframe: '1d' },
+  EEM: { basePrice: 41, volatility: 0.6, timeframe: '1d' }
+};
+
+function mulberry32(seed: number): () => number {
+  return () => {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function getIntervalMs(timeframe: Timeframe): number {
+  const minutesMap: Record<Timeframe, number> = {
+    '15m': 15,
+    '1h': 60,
+    '4h': 240,
+    '1d': 24 * 60
+  };
+  return minutesMap[timeframe] * 60 * 1000;
+}
+
+export function genCandles(symbol: SymbolKey, timeframe: Timeframe, count: number): Candle[] {
+  const config = SYMBOL_CONFIG[symbol];
+  const rng = mulberry32(hashSeed(symbol + timeframe + count));
+  const interval = getIntervalMs(timeframe);
+  const now = Date.now();
+  const candles: Candle[] = [];
+  let lastClose = config.basePrice * (0.98 + rng() * 0.04);
+
+  for (let i = count - 1; i >= 0; i -= 1) {
+    const timestamp = new Date(now - i * interval).toISOString();
+    const direction = rng() - 0.48;
+    const drift = direction * config.volatility;
+    const open = lastClose;
+    let close = open + drift;
+    close = Math.max(close, open * 0.96);
+    close = Math.min(close, open * 1.04);
+    const high = Math.max(open, close) + Math.abs(rng() * config.volatility * 0.7);
+    const low = Math.min(open, close) - Math.abs(rng() * config.volatility * 0.7);
+    const volume = Math.round(500 + rng() * 500);
+
+    candles.push({ timestamp, open: round(open), high: round(high), low: round(low), close: round(close), volume });
+    lastClose = close;
+  }
+
+  return candles;
+}
+
+function round(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+function hashSeed(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash |= 0;
+  }
+  return hash;
+}
+
+function buildSeasonality(symbol: SymbolKey, timeframe: Timeframe): SeasonalityProfile {
+  const rng = mulberry32(hashSeed(`${symbol}-${timeframe}-seasonality`));
+
+  const byMonth: SeasonalityBar[] = Array.from({ length: 12 }, (_, i) => ({
+    label: `${i + 1}`.padStart(2, '0'),
+    value: round(40 + rng() * 60)
+  }));
+
+  const dowLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const byDow: SeasonalityBar[] = dowLabels.map(label => ({
+    label,
+    value: round(30 + rng() * 70)
+  }));
+
+  const byHour = buildHeatmap(rng);
+
+  return { byMonth, byDow, byHour };
+}
+
+function buildHeatmap(rng: () => number): Array<{ dow: number; hour: number; value: number }> {
+  const cells: Array<{ dow: number; hour: number; value: number }> = [];
+  for (let dow = 0; dow < 7; dow += 1) {
+    for (let hour = 0; hour < 24; hour += 1) {
+      const base = 20 + dow * 5;
+      const modifier = Math.sin((hour / 24) * Math.PI * 2) * 10;
+      const noise = rng() * 8;
+      cells.push({ dow, hour, value: Math.round(base + modifier + noise) });
+    }
+  }
+  return cells;
+}
+
+const BASE_STATS_SUMMARY: StatsSummaryRow[] = [
+  { event: 'k_consecutive=2', target: 'up_next', n: 1200, pHat: 0.56, ciLow: 0.53, ciHigh: 0.59, lift: 0.03 },
+  { event: 'k_consecutive=3', target: 'up_next', n: 840, pHat: 0.61, ciLow: 0.57, ciHigh: 0.64, lift: 0.08 },
+  { event: 'inside_bar', target: 'break_up', n: 640, pHat: 0.42, ciLow: 0.38, ciHigh: 0.46, lift: -0.05 },
+  { event: 'vol_squeeze', target: 'range_expand', n: 950, pHat: 0.68, ciLow: 0.64, ciHigh: 0.71, lift: 0.12, qValue: 0.07 }
+];
+
+const BASE_FILTERS: FilterCard[] = [
+  {
+    id: 'benford',
+    title: 'Benford score',
+    source: 'JAVA',
+    category: 'Structure',
+    score: 0.68,
+    series: buildSeries('benford')
+  },
+  {
+    id: 'compression',
+    title: 'Compression Range',
+    source: 'JAVA',
+    category: 'Volatilité',
+    ratio: 0.22,
+    metrics: { percentile: 12 }
+  },
+  {
+    id: 'liquidity-zones',
+    title: 'Liquidity Zones',
+    source: 'JAVA',
+    category: 'Liquidity',
+    metrics: { imbalanceScore: 0.44, clusters: 5 }
+  },
+  {
+    id: 'seasonal-shift',
+    title: 'Seasonal Shift',
+    source: 'PY',
+    category: 'Seasonality',
+    description: 'Deviation between current trend and historical seasonality.',
+    metrics: { magnitude: 0.18 }
+  }
+];
+
+function buildSeries(key: string): FilterSeriesPoint[] {
+  const rng = mulberry32(hashSeed(`series-${key}`));
+  const series: FilterSeriesPoint[] = [];
+  let t = Date.now() - 24 * 3600 * 1000 * 30;
+  for (let i = 0; i < 30; i += 1) {
+    series.push({ t, v: Math.round((0.55 + rng() * 0.15) * 100) / 100 });
+    t += 24 * 3600 * 1000;
+  }
+  return series;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export const MOCK_CANDLES: Record<SymbolKey, Candle[]> = {
+  EURUSD: genCandles('EURUSD', '1h', 400),
+  GBPUSD: genCandles('GBPUSD', '1h', 400),
+  BTCUSD: genCandles('BTCUSD', '1h', 400),
+  ETHUSD: genCandles('ETHUSD', '1h', 400),
+  AAPL: genCandles('AAPL', '1d', 260),
+  MSFT: genCandles('MSFT', '1d', 260),
+  SPY: genCandles('SPY', '1d', 260),
+  EEM: genCandles('EEM', '1d', 260)
+};
+
+export const MOCK_SEASONALITY: Record<SymbolKey, SeasonalityProfile> = {
+  EURUSD: buildSeasonality('EURUSD', '1h'),
+  GBPUSD: buildSeasonality('GBPUSD', '1h'),
+  BTCUSD: buildSeasonality('BTCUSD', '1h'),
+  ETHUSD: buildSeasonality('ETHUSD', '1h'),
+  AAPL: buildSeasonality('AAPL', '1d'),
+  MSFT: buildSeasonality('MSFT', '1d'),
+  SPY: buildSeasonality('SPY', '1d'),
+  EEM: buildSeasonality('EEM', '1d')
+};
+
+export const MOCK_STATS_SUMMARY: StatsSummaryRow[] = BASE_STATS_SUMMARY;
+
+export const MOCK_FILTERS: FilterCard[] = BASE_FILTERS;
+
+export function getMockCandles(symbol: string): Candle[] {
+  const key = (symbol.toUpperCase() as SymbolKey) || 'EURUSD';
+  return clone(MOCK_CANDLES[key] ?? MOCK_CANDLES.EURUSD);
+}
+
+export function getMockSeasonality(symbol: string): SeasonalityProfile {
+  const key = (symbol.toUpperCase() as SymbolKey) || 'EURUSD';
+  return clone(MOCK_SEASONALITY[key] ?? MOCK_SEASONALITY.EURUSD);
+}
+
+export function getMockStatsSummary(): StatsSummaryRow[] {
+  return clone(MOCK_STATS_SUMMARY);
+}
+
+export function getMockFilters(predicate?: (card: FilterCard) => boolean): FilterCard[] {
+  const data = predicate ? BASE_FILTERS.filter(predicate) : BASE_FILTERS;
+  return clone(data);
+}
+
+export function getMockBenford(): FilterCard {
+  const benford = BASE_FILTERS.find(card => card.id === 'benford');
+  return clone(benford ?? BASE_FILTERS[0]);
+}

--- a/src/app/models/market-analysis.models.ts
+++ b/src/app/models/market-analysis.models.ts
@@ -1,0 +1,68 @@
+export interface Candle {
+  timestamp: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface SeasonalityBar {
+  label: string;
+  value: number;
+}
+
+export interface HeatmapCell {
+  dow: number;
+  hour: number;
+  value: number;
+}
+
+export interface SeasonalityProfile {
+  byMonth: SeasonalityBar[];
+  byDow: SeasonalityBar[];
+  byHour: HeatmapCell[];
+}
+
+export interface StatsSummaryRow {
+  event: string;
+  target: string;
+  n: number;
+  pHat: number;
+  ciLow: number;
+  ciHigh: number;
+  lift?: number;
+  qValue?: number;
+}
+
+export interface KpiSummary {
+  atrPercent: number;
+  averageRange: number;
+  skewness: number;
+  kurtosis: number;
+  maxDrawdown: number;
+}
+
+export type FilterSource = 'JAVA' | 'PY';
+
+export interface FilterSeriesPoint {
+  t: number;
+  v: number;
+}
+
+export interface FilterCard {
+  id: string;
+  title: string;
+  source: FilterSource;
+  category: string;
+  description?: string;
+  score?: number;
+  ratio?: number;
+  metrics?: Record<string, number | string>;
+  series?: FilterSeriesPoint[];
+}
+
+export interface ApiResult<T> {
+  data: T;
+  isMock: boolean;
+}

--- a/src/app/services/filters.service.ts
+++ b/src/app/services/filters.service.ts
@@ -1,0 +1,65 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { catchError, map, Observable, of } from 'rxjs';
+
+import { environment } from '../../environments/environment';
+import { ApiResult, FilterCard } from '../models/market-analysis.models';
+import { getMockBenford, getMockFilters } from '../mocks/market-mocks';
+
+@Injectable({ providedIn: 'root' })
+export class FiltersService {
+  constructor(private readonly http: HttpClient) {}
+
+  // SOURCE: JAVA
+  getMultiTFStats(symbol: string, timeframesCsv: string): Observable<ApiResult<FilterCard[]>> {
+    const params = new HttpParams().set('symbol', symbol).set('timeframes', timeframesCsv);
+
+    return this.http
+      .get<FilterCard[]>(`${environment.apiUrl}/filter/bullish-bearish-stats/multi-timeframes`, { params })
+      .pipe(
+        map(data => ({ data, isMock: false } satisfies ApiResult<FilterCard[]>)),
+        catchError(error => {
+          console.warn('Multi timeframe stats unavailable, using mock filters.', error);
+          return of({ data: getMockFilters(), isMock: true });
+        })
+      );
+  }
+
+  // SOURCE: JAVA
+  getBenford(symbol: string, timeframe: string, maxCandle?: number): Observable<ApiResult<FilterCard>> {
+    let params = new HttpParams().set('symbol', symbol).set('timeframe', timeframe);
+    if (maxCandle) {
+      params = params.set('maxCandle', maxCandle.toString());
+    }
+
+    return this.http
+      .get<FilterCard>(`${environment.apiUrl}/filter/benford/anomaly`, { params })
+      .pipe(
+        map(data => ({ data, isMock: false } satisfies ApiResult<FilterCard>)),
+        catchError(error => {
+          console.warn('Benford filter unavailable, using mock filters.', error);
+          return of({ data: getMockBenford(), isMock: true });
+        })
+      );
+  }
+
+  // SOURCE: JAVA
+  getGenericFilter<T extends object>(path: string, params: Record<string, string | number>): Observable<ApiResult<T>> {
+    let httpParams = new HttpParams();
+    Object.entries(params).forEach(([key, value]) => {
+      httpParams = httpParams.set(key, String(value));
+    });
+
+    return this.http
+      .get<T>(`${environment.apiUrl}/filter/${path}`, { params: httpParams })
+      .pipe(
+        map(data => ({ data, isMock: false } satisfies ApiResult<T>)),
+        catchError(error => {
+          console.warn(`Filter ${path} unavailable, using mock dataset.`, error);
+          const fallback = getMockFilters(card => card.id.includes(path));
+          const payload = fallback.length ? fallback : getMockFilters();
+          return of({ data: payload as unknown as T, isMock: true });
+        })
+      );
+  }
+}

--- a/src/app/services/market-stats.service.ts
+++ b/src/app/services/market-stats.service.ts
@@ -1,0 +1,159 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { catchError, map, Observable, of } from 'rxjs';
+
+import { environment } from '../../environments/environment';
+import {
+  ApiResult,
+  Candle,
+  KpiSummary,
+  SeasonalityProfile,
+  StatsSummaryRow
+} from '../models/market-analysis.models';
+import {
+  getMockCandles,
+  getMockSeasonality,
+  getMockStatsSummary
+} from '../mocks/market-mocks';
+
+@Injectable({ providedIn: 'root' })
+export class MarketStatsService {
+  constructor(private readonly http: HttpClient) {}
+
+  // SOURCE: JAVA
+  getCandles(symbol: string, timeframe: string, start?: string, end?: string): Observable<ApiResult<Candle[]>> {
+    let params = new HttpParams().set('symbol', symbol).set('timeframe', timeframe);
+    if (start) {
+      params = params.set('startDate', start);
+    }
+    if (end) {
+      params = params.set('endDate', end);
+    }
+
+    return this.http
+      .get<Candle[]>(`${environment.apiUrl}/api/finance/charts/candles`, { params })
+      .pipe(
+        map(data => ({ data, isMock: false } satisfies ApiResult<Candle[]>)),
+        catchError(error => {
+          console.warn('Candles endpoint unavailable, using mock dataset.', error);
+          return of({ data: getMockCandles(symbol), isMock: true });
+        })
+      );
+  }
+
+  // SOURCE: PY
+  getSeasonality(symbol: string, timeframe: string): Observable<ApiResult<SeasonalityProfile>> {
+    const params = new HttpParams().set('symbol', symbol).set('timeframe', timeframe);
+
+    return this.http
+      .get<SeasonalityProfile>(`${environment.pyApiUrl}/seasonality/profiles`, { params })
+      .pipe(
+        map(data => ({ data, isMock: false } satisfies ApiResult<SeasonalityProfile>)),
+        catchError(error => {
+          console.warn('Seasonality endpoint unavailable, using mock dataset.', error);
+          return of({ data: getMockSeasonality(symbol), isMock: true });
+        })
+      );
+  }
+
+  // SOURCE: PY
+  getStatsSummary(query: {
+    symbol: string;
+    timeframe: string;
+    event?: string;
+    target?: string;
+  }): Observable<ApiResult<StatsSummaryRow[]>> {
+    let params = new HttpParams().set('symbol', query.symbol).set('timeframe', query.timeframe);
+    if (query.event) {
+      params = params.set('event', query.event);
+    }
+    if (query.target) {
+      params = params.set('target', query.target);
+    }
+
+    return this.http
+      .get<Array<StatsSummaryRow | StatsSummaryRow & {
+        p_hat?: number;
+        ci_low?: number;
+        ci_high?: number;
+        q_value?: number;
+      }>>(`${environment.pyApiUrl}/stats/summary`, { params })
+      .pipe(
+        map(data => ({ data: data.map(row => normalizeStatsSummaryRow(row)), isMock: false } satisfies ApiResult<StatsSummaryRow[]>)),
+        catchError(error => {
+          console.warn('Stats summary endpoint unavailable, using mock dataset.', error);
+          return of({ data: getMockStatsSummary(), isMock: true });
+        })
+      );
+  }
+
+  computeKpisFromCandles(candles: Candle[]): KpiSummary {
+    if (!candles.length) {
+      return { atrPercent: 0, averageRange: 0, skewness: 0, kurtosis: 0, maxDrawdown: 0 };
+    }
+
+    const trueRanges: number[] = [];
+    const ranges: number[] = [];
+    const closes: number[] = candles.map(candle => candle.close);
+
+    let previousClose = candles[0].close;
+    for (const candle of candles) {
+      const highLowRange = candle.high - candle.low;
+      ranges.push(highLowRange);
+      const trueRange = Math.max(
+        candle.high - candle.low,
+        Math.abs(candle.high - previousClose),
+        Math.abs(candle.low - previousClose)
+      );
+      trueRanges.push(trueRange);
+      previousClose = candle.close;
+    }
+
+    const averageClose = closes.reduce((acc, value) => acc + value, 0) / closes.length;
+    const avgRange = ranges.reduce((acc, value) => acc + value, 0) / ranges.length;
+    const atr = trueRanges.reduce((acc, value) => acc + value, 0) / trueRanges.length;
+
+    const mean = averageClose;
+    const centered = closes.map(value => value - mean);
+    const variance = centered.reduce((acc, value) => acc + value * value, 0) / centered.length;
+    const stdDev = Math.sqrt(variance || 1);
+
+    const skewness = centered.reduce((acc, value) => acc + Math.pow(value, 3), 0) / centered.length / Math.pow(stdDev, 3);
+    const kurtosis =
+      centered.reduce((acc, value) => acc + Math.pow(value, 4), 0) / centered.length / Math.pow(stdDev, 4) - 3;
+
+    let peak = closes[0];
+    let maxDd = 0;
+    for (const close of closes) {
+      peak = Math.max(peak, close);
+      const drawdown = (close - peak) / peak;
+      maxDd = Math.min(maxDd, drawdown);
+    }
+
+    return {
+      atrPercent: Number(((atr / averageClose) * 100).toFixed(2)),
+      averageRange: Number(avgRange.toFixed(4)),
+      skewness: Number(skewness.toFixed(3)),
+      kurtosis: Number(kurtosis.toFixed(3)),
+      maxDrawdown: Number((maxDd * 100).toFixed(2))
+    };
+  }
+}
+
+function normalizeStatsSummaryRow(row: StatsSummaryRow | (StatsSummaryRow & {
+  p_hat?: number;
+  ci_low?: number;
+  ci_high?: number;
+  q_value?: number;
+})): StatsSummaryRow {
+  return {
+    event: row.event,
+    target: row.target,
+    n: row.n,
+    pHat: 'pHat' in row && typeof row.pHat === 'number' ? row.pHat : row.p_hat ?? row.pHat ?? 0,
+    ciLow: 'ciLow' in row && typeof row.ciLow === 'number' ? row.ciLow : row.ci_low ?? row.ciLow ?? 0,
+    ciHigh: 'ciHigh' in row && typeof row.ciHigh === 'number' ? row.ciHigh : row.ci_high ?? row.ciHigh ?? 0,
+    lift: row.lift,
+    qValue: 'qValue' in row && typeof row.qValue === 'number' ? row.qValue : row.q_value ?? row.qValue,
+  };
+}

--- a/src/app/services/market-stats.service.ts
+++ b/src/app/services/market-stats.service.ts
@@ -72,14 +72,12 @@ export class MarketStatsService {
     }
 
     return this.http
-      .get<Array<StatsSummaryRow | StatsSummaryRow & {
-        p_hat?: number;
-        ci_low?: number;
-        ci_high?: number;
-        q_value?: number;
-      }>>(`${environment.pyApiUrl}/stats/summary`, { params })
+      .get<RawStatsSummaryRow[]>(`${environment.pyApiUrl}/stats/summary`, { params })
       .pipe(
-        map(data => ({ data: data.map(row => normalizeStatsSummaryRow(row)), isMock: false } satisfies ApiResult<StatsSummaryRow[]>)),
+        map(data => ({
+          data: data.map(row => normalizeStatsSummaryRow(row)),
+          isMock: false
+        }) satisfies ApiResult<StatsSummaryRow[]>),
         catchError(error => {
           console.warn('Stats summary endpoint unavailable, using mock dataset.', error);
           return of({ data: getMockStatsSummary(), isMock: true });
@@ -140,20 +138,52 @@ export class MarketStatsService {
   }
 }
 
-function normalizeStatsSummaryRow(row: StatsSummaryRow | (StatsSummaryRow & {
-  p_hat?: number;
-  ci_low?: number;
-  ci_high?: number;
-  q_value?: number;
-})): StatsSummaryRow {
+function normalizeStatsSummaryRow(row: RawStatsSummaryRow): StatsSummaryRow {
   return {
     event: row.event,
     target: row.target,
     n: row.n,
-    pHat: 'pHat' in row && typeof row.pHat === 'number' ? row.pHat : row.p_hat ?? row.pHat ?? 0,
-    ciLow: 'ciLow' in row && typeof row.ciLow === 'number' ? row.ciLow : row.ci_low ?? row.ciLow ?? 0,
-    ciHigh: 'ciHigh' in row && typeof row.ciHigh === 'number' ? row.ciHigh : row.ci_high ?? row.ciHigh ?? 0,
+    pHat:
+      typeof row.pHat === 'number'
+        ? row.pHat
+        : typeof row.p_hat === 'number'
+          ? row.p_hat
+          : 0,
+    ciLow:
+      typeof row.ciLow === 'number'
+        ? row.ciLow
+        : typeof row.ci_low === 'number'
+          ? row.ci_low
+          : 0,
+    ciHigh:
+      typeof row.ciHigh === 'number'
+        ? row.ciHigh
+        : typeof row.ci_high === 'number'
+          ? row.ci_high
+          : 0,
     lift: row.lift,
-    qValue: 'qValue' in row && typeof row.qValue === 'number' ? row.qValue : row.q_value ?? row.qValue,
+    qValue:
+      typeof row.qValue === 'number'
+        ? row.qValue
+        : typeof row.q_value === 'number'
+          ? row.q_value
+          : undefined
   };
 }
+
+type RawStatsSummaryRow = {
+  event: string;
+  target: string;
+  n: number;
+  // camelCase possibles
+  pHat?: number;
+  ciLow?: number;
+  ciHigh?: number;
+  lift?: number;
+  qValue?: number;
+  // snake_case possibles (backend Python)
+  p_hat?: number;
+  ci_low?: number;
+  ci_high?: number;
+  q_value?: number;
+};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   apiBaseUrl: 'http://localhost:8090',
-  apiUrl: 'http://localhost:8090'
+  apiUrl: 'http://localhost:8090',
+  pyApiUrl: 'http://localhost:8000'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   apiBaseUrl: 'http://localhost:8090',
-  apiUrl: 'http://localhost:8090'
+  apiUrl: 'http://localhost:8090',
+  pyApiUrl: 'http://localhost:8000'
 };


### PR DESCRIPTION
## Summary
- implement market stats and filters services with mock fallbacks and KPI computation
- add a standalone market analysis page that renders seasonality charts, stats tables, and filter cards with mock badges
- introduce typed models, mock datasets, python API configuration, and angular material/http client providers

## Testing
- npm run build *(fails: ng command not found because npm install is blocked in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690cbd1439ac832381f25cee95cb3062)