### PR TITLE
feat: add data availability catalog page

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,6 +9,7 @@
         <a routerLink="/strategy-calculation">Calcul strats</a>
         <a routerLink="/screen-strategies">Strategies</a>
         <a routerLink="/live-data">Live Data</a>
+        <a routerLink="/data-availability">Data avaibility</a>
       </nav>
     </div>
     <router-outlet />

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -16,6 +16,10 @@ export const routes: Routes = [
   { path: 'live-data', component: LiveDataComponent },
   { path: 'active-robots', component: ActiveRobotsComponent },
   {
+    path: 'data-availability',
+    loadComponent: () => import('./pages/data-availability/data-availability.page').then(m => m.DataAvailabilityPageComponent)
+  },
+  {
     path: '_lab/signals',
     loadChildren: () => import('./labs/signals/signals.routes').then(m => m.SIGNALS_ROUTES)
   }

--- a/src/app/mocks/data-catalog.mocks.ts
+++ b/src/app/mocks/data-catalog.mocks.ts
@@ -1,0 +1,215 @@
+import { Candle, DataSeries, SaveResult, SymbolRef } from '../models/data-catalog.models';
+
+export const DEFAULT_SYMBOLS: SymbolRef[] = [
+  { ticker: 'EURUSD', name: 'Euro / US Dollar', market: 'FX' },
+  { ticker: 'GBPUSD', name: 'British Pound / US Dollar', market: 'FX' },
+  { ticker: 'BTCUSD', name: 'Bitcoin / US Dollar', market: 'Crypto' },
+  { ticker: 'ETHUSD', name: 'Ethereum / US Dollar', market: 'Crypto' },
+  { ticker: 'AAPL', name: 'Apple Inc.', market: 'Equity' },
+  { ticker: 'MSFT', name: 'Microsoft Corp.', market: 'Equity' },
+  { ticker: 'SPY', name: 'SPDR S&P 500 ETF', market: 'ETF' },
+  { ticker: 'EEM', name: 'iShares MSCI Emerging Markets ETF', market: 'ETF' }
+];
+
+const BASE_PRICES: Record<string, number> = {
+  EURUSD: 1.08,
+  GBPUSD: 1.26,
+  BTCUSD: 42000,
+  ETHUSD: 2300,
+  AAPL: 180,
+  MSFT: 380,
+  SPY: 520,
+  EEM: 41
+};
+
+function seededRandom(seed: number): () => number {
+  return () => {
+    seed = (seed * 9301 + 49297) % 233280;
+    return seed / 233280;
+  };
+}
+
+function parseInterval(timeframe: string): number {
+  const match = timeframe.match(/^(\d+)([mhdw])$/i);
+  if (!match) {
+    return 60 * 60 * 1000;
+  }
+  const value = Number.parseInt(match[1], 10);
+  const unit = match[2].toLowerCase();
+  switch (unit) {
+    case 'm':
+      return value * 60 * 1000;
+    case 'h':
+      return value * 60 * 60 * 1000;
+    case 'd':
+      return value * 24 * 60 * 60 * 1000;
+    case 'w':
+      return value * 7 * 24 * 60 * 60 * 1000;
+    default:
+      return 60 * 60 * 1000;
+  }
+}
+
+function createMockCandles(symbol: string, timeframe: string, days = 60): Candle[] {
+  const basePrice = BASE_PRICES[symbol] ?? 100;
+  const rng = seededRandom(symbol.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0) + timeframe.length);
+  const intervalMs = parseInterval(timeframe);
+
+  const now = Date.now();
+  const startTime = now - days * 24 * 60 * 60 * 1000;
+  const bars: Candle[] = [];
+  let price = basePrice;
+
+  const steps = Math.max(10, Math.floor((now - startTime) / intervalMs));
+
+  for (let i = 0; i < steps; i++) {
+    const t = startTime + i * intervalMs;
+    const volatility = symbol === 'BTCUSD' || symbol === 'ETHUSD' ? 0.06 : 0.01;
+    const drift = (rng() - 0.5) * volatility * price;
+    const open = price;
+    const close = Math.max(0.0001, price + drift);
+    const high = Math.max(open, close) + Math.abs(drift) * 0.5;
+    const low = Math.min(open, close) - Math.abs(drift) * 0.5;
+    const volume = 1000 + rng() * 5000;
+    bars.push({ t, o: open, h: high, l: low, c: close, v: volume });
+    price = close;
+  }
+
+  return bars;
+}
+
+export const MOCK_CANDLES: Record<string, Record<string, Candle[]>> = DEFAULT_SYMBOLS.reduce((acc, symbol) => {
+  acc[symbol.ticker] = {
+    '1h': createMockCandles(symbol.ticker, '1h'),
+    '1d': createMockCandles(symbol.ticker, '1d'),
+  };
+  return acc;
+}, {} as Record<string, Record<string, Candle[]>>);
+
+export const MOCK_SERIES: DataSeries[] = [
+  {
+    symbol: 'EURUSD',
+    broker: 'IBKR',
+    timeframe: '1h',
+    start: new Date(Date.now() - 120 * 24 * 60 * 60 * 1000).toISOString(),
+    end: new Date().toISOString(),
+    count: 2400,
+    coveragePct: 92,
+    gapsPct: 3,
+    sessions: '24/7',
+    tz: 'UTC',
+    updatedAt: new Date().toISOString(),
+    source: 'Mock'
+  },
+  {
+    symbol: 'GBPUSD',
+    broker: 'IBKR',
+    timeframe: '1d',
+    start: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString(),
+    end: new Date().toISOString(),
+    count: 360,
+    coveragePct: 98,
+    sessions: 'RTH',
+    tz: 'UTC',
+    updatedAt: new Date().toISOString(),
+    source: 'Mock'
+  },
+  {
+    symbol: 'BTCUSD',
+    broker: 'Binance',
+    timeframe: '1h',
+    start: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString(),
+    end: new Date().toISOString(),
+    count: 2100,
+    coveragePct: 96,
+    gapsPct: 1,
+    sessions: '24/7',
+    tz: 'UTC',
+    updatedAt: new Date().toISOString(),
+    source: 'Mock'
+  },
+  {
+    symbol: 'ETHUSD',
+    broker: 'Binance',
+    timeframe: '1d',
+    start: new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString(),
+    end: new Date().toISOString(),
+    count: 400,
+    coveragePct: 88,
+    gapsPct: 6,
+    sessions: '24/7',
+    tz: 'UTC',
+    updatedAt: new Date().toISOString(),
+    source: 'Mock'
+  },
+  {
+    symbol: 'AAPL',
+    broker: 'Databento CSV',
+    timeframe: '1d',
+    start: new Date(Date.now() - 720 * 24 * 60 * 60 * 1000).toISOString(),
+    end: new Date().toISOString(),
+    count: 700,
+    coveragePct: 94,
+    sessions: 'RTH',
+    tz: 'America/New_York',
+    updatedAt: new Date().toISOString(),
+    source: 'Mock'
+  },
+  {
+    symbol: 'MSFT',
+    broker: 'Databento CSV',
+    timeframe: '1h',
+    start: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString(),
+    end: new Date().toISOString(),
+    count: 900,
+    coveragePct: 85,
+    gapsPct: 10,
+    sessions: 'RTH',
+    tz: 'America/New_York',
+    updatedAt: new Date().toISOString(),
+    source: 'Mock'
+  },
+  {
+    symbol: 'SPY',
+    broker: 'IBKR',
+    timeframe: '1d',
+    start: new Date(Date.now() - 800 * 24 * 60 * 60 * 1000).toISOString(),
+    end: new Date().toISOString(),
+    count: 780,
+    coveragePct: 97,
+    sessions: 'RTH',
+    tz: 'America/New_York',
+    updatedAt: new Date().toISOString(),
+    source: 'Mock'
+  },
+  {
+    symbol: 'EEM',
+    broker: 'MEXC',
+    timeframe: '4h',
+    start: new Date(Date.now() - 150 * 24 * 60 * 60 * 1000).toISOString(),
+    end: new Date().toISOString(),
+    count: 900,
+    coveragePct: 82,
+    gapsPct: 12,
+    sessions: 'Globex',
+    tz: 'UTC',
+    updatedAt: new Date().toISOString(),
+    source: 'Mock'
+  }
+];
+
+export const MOCK_SAVE_OK: SaveResult = { ok: true, mock: true, message: 'Saved (mock)' };
+
+export function getMockCandles(symbol: string, timeframe: string): Candle[] {
+  const existing = MOCK_CANDLES[symbol]?.[timeframe];
+  if (existing) {
+    return existing;
+  }
+  const generated = createMockCandles(symbol, timeframe, 30);
+  if (!MOCK_CANDLES[symbol]) {
+    MOCK_CANDLES[symbol] = {} as Record<string, Candle[]>;
+  }
+  MOCK_CANDLES[symbol][timeframe] = generated;
+  return generated;
+}
+

--- a/src/app/models/data-catalog.models.ts
+++ b/src/app/models/data-catalog.models.ts
@@ -1,0 +1,66 @@
+export interface Candle {
+  t: number;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+  v?: number;
+}
+
+export type SessionType = '24/7' | 'RTH' | 'Globex' | '-';
+export type DataSourceType = 'API' | 'CSV' | 'Mock';
+export type ConflictPolicy = 'merge' | 'overwrite' | 'skip';
+export type RolloverPolicy = 'date' | 'volume';
+
+export interface DataSeries {
+  symbol: string;
+  broker: string;
+  venue?: string;
+  timeframe: string;
+  start: string;
+  end: string;
+  count: number;
+  coveragePct: number;
+  gapsPct?: number;
+  sessions?: SessionType;
+  tz?: string;
+  updatedAt?: string;
+  datasetId?: string;
+  source: DataSourceType;
+}
+
+export interface CoverageInfo {
+  start: string;
+  end: string;
+  count: number;
+  expected: number;
+  coveragePct: number;
+  gapsPct?: number;
+}
+
+export interface SaveRangeRequest {
+  broker: string;
+  source: Extract<DataSourceType, 'API' | 'CSV'>;
+  symbol: string;
+  timeframe: string;
+  start: string;
+  end: string;
+  venue?: string;
+  timezone?: string;
+  conflictPolicy?: ConflictPolicy;
+  rollover?: RolloverPolicy;
+}
+
+export interface SaveResult {
+  ok: boolean;
+  mock?: boolean;
+  message?: string;
+}
+
+export interface SymbolRef {
+  id?: string;
+  ticker: string;
+  name?: string;
+  market?: string;
+}
+

--- a/src/app/pages/data-availability/data-availability.page.html
+++ b/src/app/pages/data-availability/data-availability.page.html
@@ -1,0 +1,371 @@
+<mat-toolbar color="primary" class="header-toolbar">
+  <span class="title">Disponibilité des données (Candles)</span>
+  <span class="spacer"></span>
+  <button mat-icon-button aria-label="Rafraîchir" (click)="refresh()" [disabled]="loading()">
+    <mat-icon>refresh</mat-icon>
+  </button>
+  <button mat-icon-button aria-label="Exporter" (click)="exportCsv()" [disabled]="!dataSource.data.length">
+    <mat-icon>download</mat-icon>
+  </button>
+  <button mat-icon-button aria-label="Aide" (click)="showHelp()">
+    <mat-icon>help_outline</mat-icon>
+  </button>
+</mat-toolbar>
+
+<section class="filters" aria-label="Filtres de disponibilité">
+  <mat-form-field appearance="outline">
+    <mat-label>Broker</mat-label>
+    <mat-select [formControl]="filtersForm.controls.broker">
+      <mat-option value="">Tous</mat-option>
+      <mat-option *ngFor="let broker of brokers" [value]="broker">{{ broker }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline">
+    <mat-label>Type de marché</mat-label>
+    <mat-select [formControl]="filtersForm.controls.marketType">
+      <mat-option value="">Tous</mat-option>
+      <mat-option *ngFor="let type of marketTypes" [value]="type">{{ type }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="symbol-field">
+    <mat-label>Symbole</mat-label>
+    <input type="text" matInput [matAutocomplete]="symbolAuto" [formControl]="filtersForm.controls.symbol" placeholder="Rechercher un symbole" />
+    <mat-autocomplete #symbolAuto="matAutocomplete" autoActiveFirstOption>
+      <mat-option value="">Tous</mat-option>
+      <mat-option *ngFor="let symbol of filteredSymbols$ | async" [value]="symbol.ticker">
+        <div class="symbol-option">
+          <span class="ticker">{{ symbol.ticker }}</span>
+          <span class="name">{{ symbol.name }}</span>
+        </div>
+      </mat-option>
+    </mat-autocomplete>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline">
+    <mat-label>Timeframe</mat-label>
+    <mat-select [formControl]="filtersForm.controls.timeframe">
+      <mat-option value="">Tous</mat-option>
+      <mat-option *ngFor="let tf of timeframePresets" [value]="tf">{{ tf }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="range-field">
+    <mat-label>Période</mat-label>
+    <mat-date-range-input [rangePicker]="rangePicker">
+      <input matStartDate placeholder="Début" [formControl]="filtersForm.controls.start" />
+      <input matEndDate placeholder="Fin" [formControl]="filtersForm.controls.end" />
+    </mat-date-range-input>
+    <mat-datepicker-toggle matIconSuffix [for]="rangePicker"></mat-datepicker-toggle>
+    <mat-date-range-picker #rangePicker></mat-date-range-picker>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="search-field">
+    <mat-label>Recherche</mat-label>
+    <input matInput type="text" placeholder="Symbole, broker, timezone..." [formControl]="filtersForm.controls.search" />
+    <mat-icon matSuffix>search</mat-icon>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="columns-field">
+    <mat-label>Colonnes visibles</mat-label>
+    <mat-select multiple [formControl]="filtersForm.controls.columns">
+      <mat-option *ngFor="let column of allColumns" [value]="column.key" [disabled]="column.locked">
+        {{ column.label }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+</section>
+
+<mat-drawer-container class="drawer-container" autosize>
+  <mat-drawer-content>
+    <div class="table-wrapper" [class.loading]="loading()">
+      <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z1" (matSortChange)="applyFilters()">
+        <ng-container matColumnDef="symbol">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Symbole</th>
+          <td mat-cell *matCellDef="let row">
+            <div class="cell-main">
+              <span class="symbol">{{ row.symbol }}</span>
+              <span class="mock-badge" *ngIf="row.source === 'Mock'" matTooltip="Données issues du fallback mock">Mock</span>
+            </div>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="broker">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Broker / Source</th>
+          <td mat-cell *matCellDef="let row">
+            <span class="broker-badge" [ngClass]="getBrokerClass(row.broker)">{{ row.broker }}</span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="venue">
+          <th mat-header-cell *matHeaderCellDef>Venue</th>
+          <td mat-cell *matCellDef="let row">{{ row.venue || '—' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="timeframe">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Timeframe</th>
+          <td mat-cell *matCellDef="let row">{{ row.timeframe }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="start">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Début</th>
+          <td mat-cell *matCellDef="let row">{{ row.start | date: 'medium' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="end">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Fin</th>
+          <td mat-cell *matCellDef="let row">{{ row.end | date: 'medium' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="count">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Nb bougies</th>
+          <td mat-cell *matCellDef="let row">{{ row.count | number }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="coveragePct">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Couverture %</th>
+          <td mat-cell *matCellDef="let row">
+            <span [class.low-coverage]="row.coveragePct < 80">{{ row.coveragePct | number: '1.0-2' }}%</span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="gapsPct">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Gaps %</th>
+          <td mat-cell *matCellDef="let row">
+            <span *ngIf="row.gapsPct != null; else noGap">{{ row.gapsPct | number: '1.0-2' }}%</span>
+            <ng-template #noGap>—</ng-template>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="sessions">
+          <th mat-header-cell *matHeaderCellDef>Sessions</th>
+          <td mat-cell *matCellDef="let row">{{ row.sessions || '—' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="tz">
+          <th mat-header-cell *matHeaderCellDef>Timezone</th>
+          <td mat-cell *matCellDef="let row">{{ row.tz || 'UTC' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="updatedAt">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Dernière MAJ</th>
+          <td mat-cell *matCellDef="let row">{{ row.updatedAt | date: 'short' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="source">
+          <th mat-header-cell *matHeaderCellDef>Source</th>
+          <td mat-cell *matCellDef="let row">
+            <span class="source-chip" [class.source-mock]="row.source === 'Mock'">{{ row.source }}</span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>Actions</th>
+          <td mat-cell *matCellDef="let row" class="actions-cell">
+            <button mat-icon-button aria-label="Scanner gaps" matTooltip="Scanner les gaps" (click)="$event.stopPropagation(); scanGaps(row)">
+              <mat-icon>find_replace</mat-icon>
+            </button>
+            <button mat-icon-button aria-label="Recompacter" matTooltip="Recompacter (bientôt)" disabled>
+              <mat-icon>build</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="openDetails(row)"></tr>
+      </table>
+      <div class="loading-overlay" *ngIf="loading()">
+        <mat-progress-spinner diameter="48" mode="indeterminate"></mat-progress-spinner>
+      </div>
+      <mat-paginator [pageSize]="10" [pageSizeOptions]="[10, 25, 50]" showFirstLastButtons></mat-paginator>
+    </div>
+  </mat-drawer-content>
+
+  <mat-drawer #drawer position="end" mode="side" class="details-drawer" [opened]="!!selectedSeries" aria-label="Détails de la série">
+    <div class="drawer-header">
+      <h3>Détails de la série</h3>
+      <button mat-icon-button aria-label="Fermer" (click)="closeDetails()">
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
+
+    <ng-container *ngIf="selectedSeries as series">
+      <div class="drawer-content">
+        <h4>{{ series.symbol }} — {{ series.timeframe }}</h4>
+        <p class="meta">Broker : <span [ngClass]="getBrokerClass(series.broker)">{{ series.broker }}</span></p>
+        <p class="meta">Plage : {{ series.start | date: 'medium' }} → {{ series.end | date: 'medium' }}</p>
+        <p class="meta">Dernière mise à jour : {{ series.updatedAt | date: 'short' }}</p>
+
+        <div class="coverage-summary" *ngIf="detailCoverage as coverage">
+          <div class="metric">
+            <span class="label">Couverture</span>
+            <span class="value">{{ coverage.coverage | number: '1.0-2' }}%</span>
+          </div>
+          <div class="metric">
+            <span class="label">Gaps</span>
+            <span class="value">{{ coverage.gaps ?? 0 | number: '1.0-2' }}%</span>
+          </div>
+        </div>
+
+        <mat-divider></mat-divider>
+
+        <div class="histogram" aria-label="Histogramme de densité">
+          <h5>Densité (30 derniers jours)</h5>
+          <div class="hist-bars">
+            <div class="hist-bar" *ngFor="let bucket of detailHistogram" [style.height.%]="bucket.coverage">
+              <span class="tooltip">{{ bucket.day }} — {{ bucket.coverage }}%</span>
+            </div>
+          </div>
+        </div>
+
+        <mat-divider></mat-divider>
+
+        <div class="gaps" aria-label="Principaux gaps">
+          <h5>Top 5 gaps</h5>
+          <div *ngIf="topGaps.length; else noGaps" class="gap-list">
+            <div class="gap-item" *ngFor="let gap of topGaps">
+              <span class="period">{{ gap.start | date: 'short' }} → {{ gap.end | date: 'short' }}</span>
+              <span class="missing">{{ gap.missing }} bougies manquantes</span>
+            </div>
+          </div>
+          <ng-template #noGaps>
+            <p>Aucun gap significatif détecté.</p>
+          </ng-template>
+        </div>
+
+        <div class="drawer-loading" *ngIf="detailsLoading()">
+          <mat-progress-spinner diameter="36" mode="indeterminate"></mat-progress-spinner>
+        </div>
+      </div>
+    </ng-container>
+  </mat-drawer>
+</mat-drawer-container>
+
+<mat-card class="range-card" aria-label="Formulaire de sauvegarde de plage">
+  <mat-horizontal-stepper>
+    <mat-step [stepControl]="stepOne" label="Source">
+      <form [formGroup]="stepOne" class="step-content">
+        <mat-form-field appearance="outline">
+          <mat-label>Broker</mat-label>
+          <mat-select formControlName="broker" required>
+            <mat-option *ngFor="let broker of brokers" [value]="broker">{{ broker }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Type de marché</mat-label>
+          <mat-select formControlName="marketType">
+            <mat-option value="">—</mat-option>
+            <mat-option *ngFor="let type of marketTypes" [value]="type">{{ type }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Venue</mat-label>
+          <input matInput formControlName="venue" placeholder="NYSE, BINANCEUS..." />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Source</mat-label>
+          <mat-select formControlName="source" required>
+            <mat-option value="API">API</mat-option>
+            <mat-option value="CSV">CSV</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <div class="step-actions">
+          <button mat-button matStepperNext [disabled]="stepOne.invalid">Suivant</button>
+        </div>
+      </form>
+    </mat-step>
+
+    <mat-step [stepControl]="stepTwo" label="Plage">
+      <form [formGroup]="stepTwo" class="step-content">
+        <mat-form-field appearance="outline">
+          <mat-label>Symbole</mat-label>
+          <input type="text" matInput [matAutocomplete]="symbolStep" formControlName="symbol" required />
+          <mat-autocomplete #symbolStep="matAutocomplete" autoActiveFirstOption>
+            <mat-option *ngFor="let symbol of filteredStepSymbols$ | async" [value]="symbol.ticker">
+              <div class="symbol-option">
+                <span class="ticker">{{ symbol.ticker }}</span>
+                <span class="name">{{ symbol.name }}</span>
+              </div>
+            </mat-option>
+          </mat-autocomplete>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Timeframe</mat-label>
+          <mat-select formControlName="timeframe" required>
+            <mat-option *ngFor="let tf of timeframePresets" [value]="tf">{{ tf }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <div class="date-row">
+          <mat-form-field appearance="outline">
+            <mat-label>Début</mat-label>
+            <input matInput [matDatepicker]="startPicker" formControlName="start" required />
+            <mat-datepicker-toggle matIconSuffix [for]="startPicker"></mat-datepicker-toggle>
+            <mat-datepicker #startPicker></mat-datepicker>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Fin</mat-label>
+            <input matInput [matDatepicker]="endPicker" formControlName="end" required />
+            <mat-datepicker-toggle matIconSuffix [for]="endPicker"></mat-datepicker-toggle>
+            <mat-datepicker #endPicker></mat-datepicker>
+          </mat-form-field>
+        </div>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Timezone</mat-label>
+          <input matInput formControlName="timezone" placeholder="UTC, America/New_York..." />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Politique de conflits</mat-label>
+          <mat-select formControlName="conflictPolicy">
+            <mat-option value="merge">Fusionner</mat-option>
+            <mat-option value="overwrite">Ecraser</mat-option>
+            <mat-option value="skip">Ignorer</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Rollover futures</mat-label>
+          <mat-select formControlName="rollover">
+            <mat-option value="date">Date</mat-option>
+            <mat-option value="volume">Volume</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <div class="step-actions">
+          <button mat-button matStepperPrevious>Précédent</button>
+          <button mat-button matStepperNext [disabled]="stepTwo.invalid">Suivant</button>
+        </div>
+      </form>
+    </mat-step>
+
+    <mat-step label="Confirmer">
+      <div class="step-content summary-step">
+        <h4>Résumé</h4>
+        <p><strong>Broker :</strong> {{ stepOne.value.broker }}</p>
+        <p><strong>Symbole :</strong> {{ stepTwo.value.symbol }} — {{ stepTwo.value.timeframe }}</p>
+        <p><strong>Période :</strong> {{ stepTwo.value.start | date: 'short' }} → {{ stepTwo.value.end | date: 'short' }}</p>
+        <p><strong>Source :</strong> {{ stepOne.value.source }}</p>
+        <mat-checkbox [formControl]="scanAfterSave">Scanner les gaps après sauvegarde</mat-checkbox>
+
+        <div class="step-actions">
+          <button mat-button matStepperPrevious>Précédent</button>
+          <button mat-raised-button color="primary" (click)="onSaveRange(false)" [disabled]="savingRange()">Sauvegarder</button>
+          <button mat-stroked-button color="accent" (click)="onSaveRange(scanAfterSave.value ?? false)" [disabled]="savingRange()">Sauvegarder &amp; scanner</button>
+        </div>
+
+        <div class="saving-overlay" *ngIf="savingRange()">
+          <mat-progress-spinner diameter="36" mode="indeterminate"></mat-progress-spinner>
+        </div>
+      </div>
+    </mat-step>
+  </mat-horizontal-stepper>
+</mat-card>

--- a/src/app/pages/data-availability/data-availability.page.html
+++ b/src/app/pages/data-availability/data-availability.page.html
@@ -359,7 +359,7 @@
         <div class="step-actions">
           <button mat-button matStepperPrevious>Précédent</button>
           <button mat-raised-button color="primary" (click)="onSaveRange(false)" [disabled]="savingRange()">Sauvegarder</button>
-          <button mat-stroked-button color="accent" (click)="onSaveRange(scanAfterSave.value ?? false)" [disabled]="savingRange()">Sauvegarder &amp; scanner</button>
+          <button mat-stroked-button color="accent" (click)="onSaveRange(scanAfterSave.value)" [disabled]="savingRange()">Sauvegarder &amp; scanner</button>
         </div>
 
         <div class="saving-overlay" *ngIf="savingRange()">

--- a/src/app/pages/data-availability/data-availability.page.scss
+++ b/src/app/pages/data-availability/data-availability.page.scss
@@ -1,0 +1,331 @@
+.header-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+
+  .title {
+    font-size: 1.2rem;
+    font-weight: 600;
+  }
+
+  .spacer {
+    flex: 1;
+  }
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  padding: 1.5rem 1rem;
+  align-items: end;
+  background-color: var(--mat-sys-surface-container-low, #f8f9fb);
+
+  .symbol-field {
+    min-width: 220px;
+  }
+
+  .search-field {
+    min-width: 260px;
+  }
+
+  .columns-field {
+    min-width: 220px;
+  }
+
+  .range-field {
+    min-width: 240px;
+  }
+
+  .symbol-option {
+    display: flex;
+    flex-direction: column;
+
+    .ticker {
+      font-weight: 600;
+    }
+
+    .name {
+      font-size: 0.85rem;
+      opacity: 0.7;
+    }
+  }
+}
+
+.drawer-container {
+  display: flex;
+  min-height: 520px;
+}
+
+.table-wrapper {
+  position: relative;
+  margin: 0 1rem;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.table-wrapper.loading {
+  opacity: 0.5;
+}
+
+.table-wrapper table {
+  width: 100%;
+}
+
+.cell-main {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.symbol {
+  font-weight: 600;
+}
+
+.mock-badge {
+  background-color: #ffcc80;
+  color: #5d4037;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.broker-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.broker-binance {
+  background: #f7d34b;
+  color: #2f2f2f;
+}
+
+.broker-mexc {
+  background: #1ba784;
+  color: #fff;
+}
+
+.broker-ibkr {
+  background: #1976d2;
+  color: #fff;
+}
+
+.broker-csv {
+  background: #757575;
+  color: #fff;
+}
+
+.broker-generic {
+  background: #e0e0e0;
+  color: #424242;
+}
+
+.source-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(33, 33, 33, 0.08);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.source-chip.source-mock {
+  background: rgba(229, 57, 53, 0.15);
+  color: #b71c1c;
+}
+
+.low-coverage {
+  color: #d32f2f;
+  font-weight: 600;
+}
+
+.actions-cell button + button {
+  margin-left: 0.5rem;
+}
+
+.loading-overlay,
+.saving-overlay,
+.drawer-loading {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loading-overlay {
+  backdrop-filter: blur(2px);
+}
+
+.mat-mdc-paginator {
+  border-top: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.details-drawer {
+  width: min(420px, 90vw);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.drawer-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.coverage-summary {
+  display: flex;
+  gap: 1.5rem;
+
+  .metric {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+
+    .label {
+      font-size: 0.8rem;
+      opacity: 0.7;
+    }
+
+    .value {
+      font-size: 1.2rem;
+      font-weight: 600;
+    }
+  }
+}
+
+.histogram {
+  .hist-bars {
+    display: grid;
+    grid-template-columns: repeat(30, minmax(4px, 1fr));
+    gap: 3px;
+    align-items: end;
+    height: 120px;
+  }
+
+  .hist-bar {
+    position: relative;
+    width: 100%;
+    background: linear-gradient(180deg, #64b5f6, #1e88e5);
+    border-radius: 3px;
+
+    .tooltip {
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translate(-50%, -6px);
+      background: rgba(33, 33, 33, 0.85);
+      color: #fff;
+      padding: 0.2rem 0.4rem;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      white-space: nowrap;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+      pointer-events: none;
+    }
+
+    &:hover .tooltip {
+      opacity: 1;
+    }
+  }
+}
+
+.gaps {
+  .gap-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .gap-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    background: rgba(33, 33, 33, 0.04);
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+
+    .period {
+      font-weight: 600;
+    }
+
+    .missing {
+      font-size: 0.85rem;
+      opacity: 0.75;
+    }
+  }
+}
+
+.range-card {
+  margin: 1.5rem 1rem 2rem;
+  padding: 1rem 1.5rem 2rem;
+}
+
+.step-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem 1.5rem;
+}
+
+.date-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.step-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.summary-step {
+  position: relative;
+  gap: 0.75rem;
+}
+
+@media (max-width: 960px) {
+  .filters {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .drawer-container {
+    flex-direction: column;
+  }
+
+  .details-drawer {
+    width: 100%;
+    position: static;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+}

--- a/src/app/pages/data-availability/data-availability.page.ts
+++ b/src/app/pages/data-availability/data-availability.page.ts
@@ -129,7 +129,9 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
   ] as const;
 
   readonly lockedColumns = new Set(this.allColumns.filter(c => c.locked).map(c => c.key));
-  readonly visibleColumns = signal(new Set(this.allColumns.map(c => c.key)));
+  readonly visibleColumns = signal<Set<string>>(
+    new Set(this.allColumns.map(c => c.key))
+  );
   readonly columnLabels = this.allColumns.reduce<Record<string, string>>((acc, col) => {
     acc[col.key] = col.label;
     return acc;
@@ -372,8 +374,8 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
       end: this.toIsoString(stepTwoValue.end),
       venue: stepOneValue.venue || undefined,
       timezone: stepTwoValue.timezone || undefined,
-      conflictPolicy: stepTwoValue.conflictPolicy || undefined,
-      rollover: stepTwoValue.rollover || undefined,
+      conflictPolicy: (stepTwoValue.conflictPolicy || undefined) as SaveRangeRequest['conflictPolicy'],
+      rollover: (stepTwoValue.rollover || undefined) as SaveRangeRequest['rollover'],
     };
 
     this.savingRange.set(true);
@@ -393,7 +395,7 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
   resetForm(): void {
     this.stepOne.reset({ broker: '', marketType: '', venue: '', source: 'API' });
     this.stepTwo.reset({ symbol: '', timeframe: '', start: null, end: null, timezone: 'UTC', conflictPolicy: 'merge', rollover: 'date' });
-    this.scanAfterSave.set(true);
+    this.scanAfterSave.setValue(true);
   }
 
   private handleSaveResult(result: SaveResult, payload: SaveRangeRequest, scanAfter: boolean): void {
@@ -545,8 +547,10 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
       case 'end':
       case 'updatedAt':
         return series[column] ? new Date(series[column]).toISOString() : '';
-      default:
-        return String((series as Record<string, unknown>)[column] ?? '');
+      default: {
+        const record = series as unknown as Record<string, unknown>;
+        return String(record[column] ?? '');
+      }
     }
   }
 }

--- a/src/app/pages/data-availability/data-availability.page.ts
+++ b/src/app/pages/data-availability/data-availability.page.ts
@@ -1,0 +1,553 @@
+import { CommonModule } from '@angular/common';
+import { AfterViewInit, Component, OnInit, ViewChild, inject, signal } from '@angular/core';
+import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSidenavModule, MatDrawer } from '@angular/material/sidenav';
+import { MatCardModule } from '@angular/material/card';
+import { MatStepperModule } from '@angular/material/stepper';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatDividerModule } from '@angular/material/divider';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { debounceTime, map, startWith } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { DataCatalogService } from '../../services/data-catalog.service';
+import { DataSeries, SaveRangeRequest, SaveResult, SymbolRef, Candle } from '../../models/data-catalog.models';
+import { SymbolService } from '../../services/symbol.service';
+import { DEFAULT_SYMBOLS } from '../../mocks/data-catalog.mocks';
+
+interface HistogramBucket {
+  day: string;
+  coverage: number;
+}
+
+interface GapDetail {
+  start: string;
+  end: string;
+  missing: number;
+}
+
+@Component({
+  selector: 'app-data-availability-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatToolbarModule,
+    MatButtonModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatAutocompleteModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatProgressSpinnerModule,
+    MatSidenavModule,
+    MatCardModule,
+    MatStepperModule,
+    MatCheckboxModule,
+    MatTooltipModule,
+    MatSnackBarModule,
+    MatDividerModule,
+  ],
+  templateUrl: './data-availability.page.html',
+  styleUrls: ['./data-availability.page.scss'],
+})
+export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly dataCatalog = inject(DataCatalogService);
+  private readonly symbolService = inject(SymbolService);
+
+  @ViewChild(MatPaginator) paginator?: MatPaginator;
+  @ViewChild(MatSort) sort?: MatSort;
+  @ViewChild(MatDrawer) drawer?: MatDrawer;
+
+  readonly filtersForm = this.fb.nonNullable.group({
+    search: [''],
+    broker: [''],
+    marketType: [''],
+    symbol: [''],
+    timeframe: [''],
+    start: [null as Date | null],
+    end: [null as Date | null],
+    columns: [['start', 'end', 'count', 'coveragePct', 'gapsPct', 'sessions', 'tz', 'updatedAt', 'source'] as string[]],
+  });
+
+  readonly stepOne = this.fb.nonNullable.group({
+    broker: ['', Validators.required],
+    marketType: [''],
+    venue: [''],
+    source: ['API' as SaveRangeRequest['source'], Validators.required],
+  });
+
+  readonly stepTwo = this.fb.group({
+    symbol: ['', Validators.required],
+    timeframe: ['', Validators.required],
+    start: [null as Date | null, Validators.required],
+    end: [null as Date | null, Validators.required],
+    timezone: ['UTC'],
+    conflictPolicy: ['merge'],
+    rollover: ['date'],
+  });
+
+  readonly scanAfterSave = new FormControl(true, { nonNullable: true });
+
+  readonly dataSource = new MatTableDataSource<DataSeries>([]);
+  readonly allColumns = [
+    { key: 'symbol', label: 'Symbole', locked: true },
+    { key: 'broker', label: 'Broker/Source', locked: true },
+    { key: 'venue', label: 'Venue', locked: false },
+    { key: 'timeframe', label: 'Timeframe', locked: true },
+    { key: 'start', label: 'Date début', locked: false },
+    { key: 'end', label: 'Date fin', locked: false },
+    { key: 'count', label: 'Nb bougies', locked: false },
+    { key: 'coveragePct', label: 'Couverture %', locked: false },
+    { key: 'gapsPct', label: 'Gaps %', locked: false },
+    { key: 'sessions', label: 'Sessions', locked: false },
+    { key: 'tz', label: 'Timezone', locked: false },
+    { key: 'updatedAt', label: 'Dernière MAJ', locked: false },
+    { key: 'source', label: 'Source', locked: false },
+    { key: 'actions', label: 'Actions', locked: true },
+  ] as const;
+
+  readonly lockedColumns = new Set(this.allColumns.filter(c => c.locked).map(c => c.key));
+  readonly visibleColumns = signal(new Set(this.allColumns.map(c => c.key)));
+  readonly columnLabels = this.allColumns.reduce<Record<string, string>>((acc, col) => {
+    acc[col.key] = col.label;
+    return acc;
+  }, {});
+
+  readonly timeframePresets = ['1m', '5m', '15m', '1h', '4h', '1d', '1w'];
+  readonly brokers = ['Binance', 'MEXC', 'IBKR', 'Databento CSV', 'CSV TradingView', 'Autre'];
+  readonly marketTypes = ['FX', 'Crypto', 'Equity', 'ETF', 'Futures'];
+
+  symbols: SymbolRef[] = [];
+  filteredSymbols$!: Observable<SymbolRef[]>;
+  filteredStepSymbols$!: Observable<SymbolRef[]>;
+
+  private seriesCache: DataSeries[] = [];
+  loading = signal(false);
+  detailsLoading = signal(false);
+  savingRange = signal(false);
+
+  selectedSeries?: DataSeries;
+  detailCoverage?: { coverage: number; gaps?: number };
+  detailHistogram: HistogramBucket[] = [];
+  topGaps: GapDetail[] = [];
+
+  ngOnInit(): void {
+    this.symbolService
+      .getAll()
+      .pipe(takeUntilDestroyed())
+      .subscribe(list => {
+        this.symbols = list.length ? list : DEFAULT_SYMBOLS;
+        this.setupAutocomplete();
+      });
+
+    this.filtersForm.controls.columns.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe(selection => {
+        const locked = new Set(this.lockedColumns);
+        const merged = new Set<string>([...locked, ...selection]);
+        this.visibleColumns.set(merged);
+      });
+
+    this.filtersForm.controls.search.valueChanges
+      .pipe(debounceTime(200), takeUntilDestroyed())
+      .subscribe(() => this.applyFilters());
+
+    this.filtersForm.controls.start.valueChanges
+      .pipe(debounceTime(100), takeUntilDestroyed())
+      .subscribe(() => this.applyFilters());
+
+    this.filtersForm.controls.end.valueChanges
+      .pipe(debounceTime(100), takeUntilDestroyed())
+      .subscribe(() => this.applyFilters());
+
+    const fetchTriggers = [
+      this.filtersForm.controls.broker.valueChanges,
+      this.filtersForm.controls.marketType.valueChanges,
+      this.filtersForm.controls.symbol.valueChanges,
+      this.filtersForm.controls.timeframe.valueChanges,
+    ];
+
+    fetchTriggers.forEach(stream =>
+      stream.pipe(debounceTime(250), takeUntilDestroyed()).subscribe(() => this.refresh())
+    );
+
+    this.dataSource.filterPredicate = (data, filter) => {
+      const normalized = filter.trim().toLowerCase();
+      if (!normalized) {
+        return true;
+      }
+      const haystack = [
+        data.symbol,
+        data.broker,
+        data.timeframe,
+        data.venue ?? '',
+        data.sessions ?? '',
+        data.tz ?? '',
+        data.source,
+      ]
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(normalized);
+    };
+
+    this.refresh();
+  }
+
+  ngAfterViewInit(): void {
+    if (this.paginator) {
+      this.dataSource.paginator = this.paginator;
+    }
+    if (this.sort) {
+      this.dataSource.sort = this.sort;
+    }
+  }
+
+  get displayedColumns(): string[] {
+    return this.allColumns
+      .map(col => col.key)
+      .filter(key => this.visibleColumns().has(key));
+  }
+
+  refresh(): void {
+    const { broker, marketType, symbol, timeframe } = this.filtersForm.getRawValue();
+    this.loading.set(true);
+    this.dataCatalog
+      .listSeriesAvailability({ broker: broker || undefined, marketType: marketType || undefined, symbol: symbol || undefined, timeframe: timeframe || undefined })
+      .pipe(takeUntilDestroyed())
+      .subscribe({
+        next: series => {
+          this.seriesCache = series;
+          this.applyFilters();
+          this.loading.set(false);
+        },
+        error: err => {
+          console.error('Failed to load series availability', err);
+          this.seriesCache = [];
+          this.applyFilters();
+          this.loading.set(false);
+        },
+      });
+  }
+
+  applyFilters(): void {
+    let filtered = [...this.seriesCache];
+    const { start, end, search } = this.filtersForm.getRawValue();
+
+    if (start instanceof Date) {
+      const startMs = start.getTime();
+      filtered = filtered.filter(item => new Date(item.start).getTime() >= startMs);
+    }
+
+    if (end instanceof Date) {
+      const endMs = end.getTime();
+      filtered = filtered.filter(item => new Date(item.end).getTime() <= endMs);
+    }
+
+    this.dataSource.data = filtered;
+    const searchValue = (search ?? '').toLowerCase();
+    this.dataSource.filter = searchValue;
+
+    if (this.paginator) {
+      this.paginator.firstPage();
+    }
+  }
+
+  openDetails(row: DataSeries): void {
+    this.selectedSeries = row;
+    this.detailHistogram = [];
+    this.topGaps = [];
+    this.detailCoverage = undefined;
+    this.detailsLoading.set(true);
+    this.drawer?.open();
+
+    this.dataCatalog
+      .probeSeries(row.symbol, row.timeframe)
+      .pipe(takeUntilDestroyed())
+      .subscribe({
+        next: candles => {
+          const coverage = this.dataCatalog.computeCoverage(candles, row.timeframe);
+          this.detailCoverage = { coverage: coverage.coveragePct, gaps: coverage.gapsPct };
+          this.detailHistogram = this.buildHistogram(candles);
+          this.topGaps = this.extractTopGaps(candles, row.timeframe);
+          this.detailsLoading.set(false);
+        },
+        error: err => {
+          console.error('Failed to probe series', err);
+          this.detailHistogram = [];
+          this.detailsLoading.set(false);
+        },
+      });
+  }
+
+  closeDetails(): void {
+    this.drawer?.close();
+    this.selectedSeries = undefined;
+    this.detailHistogram = [];
+    this.topGaps = [];
+  }
+
+  scanGaps(series: DataSeries): void {
+    this.dataCatalog
+      .probeSeries(series.symbol, series.timeframe)
+      .pipe(takeUntilDestroyed())
+      .subscribe(candles => {
+        const coverage = this.dataCatalog.computeCoverage(candles, series.timeframe);
+        const updated: DataSeries = {
+          ...series,
+          start: coverage.start,
+          end: coverage.end,
+          count: coverage.count,
+          coveragePct: coverage.coveragePct,
+          gapsPct: coverage.gapsPct,
+          updatedAt: new Date().toISOString(),
+          source: series.source ?? 'API',
+        };
+        this.upsertSeries(updated);
+        this.snackBar.open('Analyse des gaps terminée', 'Fermer', { duration: 3000 });
+      });
+  }
+
+  exportCsv(): void {
+    const columns = this.displayedColumns.filter(col => col !== 'actions');
+    const header = columns.map(col => this.columnLabels[col] ?? col);
+    const rows = this.dataSource.data.map(series =>
+      columns
+        .map(column => this.formatCell(series, column))
+        .map(value => `"${value.replace(/"/g, '""')}"`)
+        .join(',')
+    );
+    const csvContent = [header.join(','), ...rows].join('\n');
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'data-availability.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  showHelp(): void {
+    this.snackBar.open('Renseignez les filtres pour rafraîchir la table et utilisez le formulaire pour ingérer de nouvelles plages.', 'OK', {
+      duration: 5000,
+    });
+  }
+
+  onSaveRange(scanAfter: boolean): void {
+    if (this.stepOne.invalid || this.stepTwo.invalid) {
+      this.stepOne.markAllAsTouched();
+      this.stepTwo.markAllAsTouched();
+      return;
+    }
+    const stepOneValue = this.stepOne.getRawValue();
+    const stepTwoValue = this.stepTwo.getRawValue();
+
+    const payload: SaveRangeRequest = {
+      broker: stepOneValue.broker,
+      source: stepOneValue.source,
+      symbol: stepTwoValue.symbol!,
+      timeframe: stepTwoValue.timeframe!,
+      start: this.toIsoString(stepTwoValue.start),
+      end: this.toIsoString(stepTwoValue.end),
+      venue: stepOneValue.venue || undefined,
+      timezone: stepTwoValue.timezone || undefined,
+      conflictPolicy: stepTwoValue.conflictPolicy || undefined,
+      rollover: stepTwoValue.rollover || undefined,
+    };
+
+    this.savingRange.set(true);
+    this.dataCatalog
+      .saveRange(payload)
+      .pipe(takeUntilDestroyed())
+      .subscribe({
+        next: result => this.handleSaveResult(result, payload, scanAfter),
+        error: err => {
+          console.error('Save range failed', err);
+          this.handleSaveResult({ ok: true, mock: true, message: 'Saved (mock fallback)' }, payload, scanAfter);
+        },
+        complete: () => this.savingRange.set(false),
+      });
+  }
+
+  resetForm(): void {
+    this.stepOne.reset({ broker: '', marketType: '', venue: '', source: 'API' });
+    this.stepTwo.reset({ symbol: '', timeframe: '', start: null, end: null, timezone: 'UTC', conflictPolicy: 'merge', rollover: 'date' });
+    this.scanAfterSave.set(true);
+  }
+
+  private handleSaveResult(result: SaveResult, payload: SaveRangeRequest, scanAfter: boolean): void {
+    this.savingRange.set(false);
+    const message = result.mock ? result.message ?? 'Sauvegarde simulée' : result.message ?? 'Sauvegarde déclenchée';
+    this.snackBar.open(message, 'Fermer', { duration: 4000 });
+
+    if (!result.ok) {
+      return;
+    }
+
+    const newSeries: DataSeries = {
+      symbol: payload.symbol,
+      broker: payload.broker,
+      timeframe: payload.timeframe,
+      start: payload.start,
+      end: payload.end,
+      count: 0,
+      coveragePct: 0,
+      sessions: '-',
+      tz: payload.timezone ?? 'UTC',
+      updatedAt: new Date().toISOString(),
+      source: result.mock ? 'Mock' : payload.source,
+    };
+
+    this.upsertSeries(newSeries);
+
+    if (scanAfter) {
+      this.scanGaps(newSeries);
+    }
+  }
+
+  private upsertSeries(series: DataSeries): void {
+    const existingIndex = this.seriesCache.findIndex(item => item.symbol === series.symbol && item.timeframe === series.timeframe && item.broker === series.broker);
+    if (existingIndex >= 0) {
+      this.seriesCache.splice(existingIndex, 1, { ...this.seriesCache[existingIndex], ...series });
+    } else {
+      this.seriesCache = [series, ...this.seriesCache];
+    }
+    this.applyFilters();
+  }
+
+  private setupAutocomplete(): void {
+    this.filteredSymbols$ = this.filtersForm.controls.symbol.valueChanges.pipe(
+      startWith(this.filtersForm.controls.symbol.value ?? ''),
+      map(value => this.filterSymbols(value || ''))
+    );
+
+    this.filteredStepSymbols$ = this.stepTwo.controls.symbol.valueChanges.pipe(
+      startWith(this.stepTwo.controls.symbol.value ?? ''),
+      map(value => this.filterSymbols((value as string) || ''))
+    );
+  }
+
+  private filterSymbols(value: string): SymbolRef[] {
+    const search = value.toLowerCase();
+    return this.symbols.filter(symbol =>
+      symbol.ticker.toLowerCase().includes(search) || (symbol.name ?? '').toLowerCase().includes(search)
+    );
+  }
+
+  getBrokerClass(broker: string): string {
+    const lower = (broker ?? '').toLowerCase();
+    if (lower.includes('binance')) {
+      return 'broker-binance';
+    }
+    if (lower.includes('mexc')) {
+      return 'broker-mexc';
+    }
+    if (lower.includes('ibkr')) {
+      return 'broker-ibkr';
+    }
+    if (lower.includes('csv') || lower.includes('databento')) {
+      return 'broker-csv';
+    }
+    return 'broker-generic';
+  }
+
+  private buildHistogram(candles: Candle[]): HistogramBucket[] {
+    if (!candles.length) {
+      return [];
+    }
+    const buckets = new Map<string, number>();
+    candles.forEach(candle => {
+      const day = new Date(candle.t).toISOString().slice(0, 10);
+      buckets.set(day, (buckets.get(day) ?? 0) + 1);
+    });
+    const entries = Array.from(buckets.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+    const recent = entries.slice(-30);
+    const max = Math.max(...recent.map(([, count]) => count), 1);
+    return recent.map(([day, count]) => ({ day, coverage: Math.round((count / max) * 100) }));
+  }
+
+  private extractTopGaps(candles: Candle[], timeframe: string): GapDetail[] {
+    if (candles.length < 2) {
+      return [];
+    }
+    const sorted = [...candles].sort((a, b) => a.t - b.t);
+    const frameMs = this.timeframeToMs(timeframe) || 0;
+    const gaps: GapDetail[] = [];
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1];
+      const current = sorted[i];
+      const diff = current.t - prev.t;
+      if (frameMs > 0 && diff > frameMs * 1.5) {
+        const missing = Math.round(diff / frameMs) - 1;
+        gaps.push({ start: new Date(prev.t).toISOString(), end: new Date(current.t).toISOString(), missing });
+      }
+    }
+    return gaps.sort((a, b) => b.missing - a.missing).slice(0, 5);
+  }
+
+  private timeframeToMs(timeframe: string): number {
+    const match = timeframe?.match(/^(\d+)([smhdw])$/i);
+    if (!match) {
+      return 0;
+    }
+    const value = Number.parseInt(match[1], 10);
+    const unit = match[2].toLowerCase();
+    switch (unit) {
+      case 's':
+        return value * 1000;
+      case 'm':
+        return value * 60 * 1000;
+      case 'h':
+        return value * 60 * 60 * 1000;
+      case 'd':
+        return value * 24 * 60 * 60 * 1000;
+      case 'w':
+        return value * 7 * 24 * 60 * 60 * 1000;
+      default:
+        return 0;
+    }
+  }
+
+  private toIsoString(value: Date | null): string {
+    if (!value) {
+      return new Date().toISOString();
+    }
+    return new Date(value).toISOString();
+  }
+
+  private formatCell(series: DataSeries, column: string): string {
+    switch (column) {
+      case 'coveragePct':
+      case 'gapsPct':
+        return series[column] != null ? `${Number(series[column]).toFixed(2)}%` : '';
+      case 'start':
+      case 'end':
+      case 'updatedAt':
+        return series[column] ? new Date(series[column]).toISOString() : '';
+      default:
+        return String((series as Record<string, unknown>)[column] ?? '');
+    }
+  }
+}
+

--- a/src/app/services/data-catalog.service.spec.ts
+++ b/src/app/services/data-catalog.service.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { DataCatalogService } from './data-catalog.service';
+import { Candle } from '../models/data-catalog.models';
+
+describe('DataCatalogService', () => {
+  let service: DataCatalogService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+    service = TestBed.inject(DataCatalogService);
+  });
+
+  it('should compute coverage and gaps for hourly candles', () => {
+    const base = Date.parse('2024-01-01T00:00:00Z');
+    const candles: Candle[] = [0, 1, 2, 4].map(offset => {
+      const time = base + offset * 60 * 60 * 1000;
+      const price = 100 + offset;
+      return { t: time, o: price, h: price + 1, l: price - 1, c: price + 0.5 };
+    });
+
+    const coverage = service.computeCoverage(candles, '1h');
+
+    expect(coverage.count).toBe(4);
+    expect(coverage.expected).toBe(5);
+    expect(coverage.coveragePct).toBeCloseTo(80, 5);
+    expect(coverage.gapsPct).toBeCloseTo(20, 5);
+    expect(coverage.start).toBe(new Date(base).toISOString());
+    expect(coverage.end).toBe(new Date(base + 4 * 60 * 60 * 1000).toISOString());
+  });
+
+  it('should handle empty candle list', () => {
+    const coverage = service.computeCoverage([], '1h');
+    expect(coverage.count).toBe(0);
+    expect(coverage.expected).toBe(0);
+    expect(coverage.coveragePct).toBe(0);
+    expect(coverage.gapsPct).toBeUndefined();
+    expect(coverage.start).toBe('');
+    expect(coverage.end).toBe('');
+  });
+});

--- a/src/app/services/data-catalog.service.ts
+++ b/src/app/services/data-catalog.service.ts
@@ -1,0 +1,307 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, forkJoin, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import {
+  Candle,
+  CoverageInfo,
+  DataSeries,
+  SaveRangeRequest,
+  SaveResult,
+  SymbolRef,
+} from '../models/data-catalog.models';
+import { DEFAULT_SYMBOLS, MOCK_SAVE_OK, MOCK_SERIES, getMockCandles } from '../mocks/data-catalog.mocks';
+
+@Injectable({ providedIn: 'root' })
+export class DataCatalogService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = environment.apiUrl;
+  private readonly mockedProbes = new Set<string>();
+
+  listSymbols(): Observable<SymbolRef[]> {
+    return this.http.get<SymbolRef[]>(`${this.apiUrl}/api/finance/symbols`).pipe(
+      tap(list => console.log('[DataCatalogService] listSymbols', list?.length ?? 0)),
+      map(list => (Array.isArray(list) ? list : [])),
+      catchError(err => {
+        console.warn('[DataCatalogService] fallback symbols', err);
+        return of(DEFAULT_SYMBOLS);
+      })
+    );
+  }
+
+  probeSeries(symbol: string, timeframe: string): Observable<Candle[]> {
+    const key = this.buildProbeKey(symbol, timeframe);
+    const params = new HttpParams().set('symbol', symbol).set('timeframe', timeframe);
+    return this.http
+      .get<Candle[]>(`${this.apiUrl}/api/finance/charts/candles`, { params })
+      .pipe(
+        map(response => (Array.isArray(response) ? response : [])),
+        tap(() => this.mockedProbes.delete(key)),
+        catchError(err => {
+          console.warn('[DataCatalogService] probeSeries fallback', symbol, timeframe, err);
+          this.mockedProbes.add(key);
+          const fallback = getMockCandles(symbol, timeframe);
+          return of(fallback);
+        })
+      );
+  }
+
+  computeCoverage(candles: Candle[], timeframe: string): CoverageInfo {
+    if (!Array.isArray(candles) || candles.length === 0) {
+      return {
+        start: '',
+        end: '',
+        count: 0,
+        expected: 0,
+        coveragePct: 0,
+      };
+    }
+
+    const sorted = [...candles].sort((a, b) => a.t - b.t);
+    const first = sorted[0];
+    const last = sorted[sorted.length - 1];
+    const frameMs = this.timeframeToMs(timeframe);
+
+    const spanMs = Math.max(0, last.t - first.t);
+    const expected = frameMs > 0 ? Math.floor(spanMs / frameMs) + 1 : sorted.length;
+    const count = sorted.length;
+    const coveragePct = expected > 0 ? Math.min(100, (count / expected) * 100) : 0;
+
+    let missing = 0;
+    if (frameMs > 0 && count > 1) {
+      for (let i = 1; i < sorted.length; i++) {
+        const gap = sorted[i].t - sorted[i - 1].t;
+        if (gap > frameMs * 1.5) {
+          missing += Math.max(0, Math.round(gap / frameMs) - 1);
+        }
+      }
+    }
+    const gapsPct = expected > 0 && missing > 0 ? Math.min(100, (missing / expected) * 100) : undefined;
+
+    return {
+      start: new Date(first.t).toISOString(),
+      end: new Date(last.t).toISOString(),
+      count,
+      expected,
+      coveragePct: Number(coveragePct.toFixed(2)),
+      gapsPct: gapsPct != null ? Number(gapsPct.toFixed(2)) : undefined,
+    };
+  }
+
+  listSeriesAvailability(query: {
+    broker?: string;
+    marketType?: string;
+    symbol?: string;
+    timeframe?: string;
+  }): Observable<DataSeries[]> {
+    let params = new HttpParams();
+    if (query.symbol) params = params.set('symbol', query.symbol);
+    if (query.timeframe) params = params.set('timeframe', query.timeframe);
+    if (query.broker) params = params.set('broker', query.broker);
+    if (query.marketType) params = params.set('marketType', query.marketType);
+
+    return this.http
+      .get<DataSeries[]>(`${this.apiUrl}/api/finance/charts/availability`, { params })
+      .pipe(
+        map(series => this.normalizeSeries(series ?? [])),
+        catchError(err => {
+          console.warn('[DataCatalogService] availability endpoint unavailable, probing candles', err);
+          return this.buildSeriesFromProbes(query).pipe(
+            catchError(innerErr => {
+              console.warn('[DataCatalogService] probe fallback failed, using mock series', innerErr);
+              return of(MOCK_SERIES);
+            })
+          );
+        })
+      );
+  }
+
+  saveRange(req: SaveRangeRequest): Observable<SaveResult> {
+    const broker = (req.broker ?? '').toLowerCase();
+
+    if (broker.includes('binance')) {
+      const params = new HttpParams()
+        .set('symbol', req.symbol)
+        .set('interval', req.timeframe)
+        .set('startDate', req.start)
+        .set('endDate', req.end);
+      return this.http.get(`${this.apiUrl}/binance/historical-range`, { params }).pipe(
+        map(() => ({ ok: true, mock: false, message: 'Binance range requested' } as SaveResult)),
+        catchError(err => {
+          console.warn('[DataCatalogService] binance range fallback', err);
+          return of({ ...MOCK_SAVE_OK });
+        })
+      );
+    }
+
+    if (req.source === 'CSV') {
+      const body = {
+        symbol: req.symbol,
+        timeframe: req.timeframe,
+        startDate: req.start,
+        endDate: req.end,
+        timezone: req.timezone,
+        venue: req.venue,
+        conflictPolicy: req.conflictPolicy,
+        rollover: req.rollover,
+      };
+      const endpoint = broker.includes('databento') || broker.includes('cme')
+        ? `${this.apiUrl}/api/finance/charts/load-csv/cme`
+        : `${this.apiUrl}/api/finance/charts/load-csv/tradingview`;
+      return this.http.post(endpoint, body).pipe(
+        map(() => ({ ok: true, mock: false, message: 'CSV ingestion submitted' } as SaveResult)),
+        catchError(err => {
+          console.warn('[DataCatalogService] csv ingestion fallback', err);
+          return of({ ...MOCK_SAVE_OK });
+        })
+      );
+    }
+
+    if (broker.includes('ibkr') || broker.includes('mexc')) {
+      console.warn('[DataCatalogService] broker not yet supported, returning mock');
+      return of({ ...MOCK_SAVE_OK });
+    }
+
+    console.warn('[DataCatalogService] generic save fallback');
+    return of({ ...MOCK_SAVE_OK });
+  }
+
+  private buildSeriesFromProbes(query: {
+    broker?: string;
+    marketType?: string;
+    symbol?: string;
+    timeframe?: string;
+  }): Observable<DataSeries[]> {
+    const symbols = query.symbol
+      ? [query.symbol]
+      : DEFAULT_SYMBOLS.map(s => s.ticker);
+    const timeframes = query.timeframe ? [query.timeframe] : ['1h', '4h', '1d'];
+    const combos = symbols.flatMap(symbol => timeframes.map(timeframe => ({ symbol, timeframe })));
+
+    if (combos.length === 0) {
+      return of(MOCK_SERIES);
+    }
+
+    const requests = combos.map(({ symbol, timeframe }) =>
+      this.probeSeries(symbol, timeframe).pipe(
+        map(candles => {
+          if (!candles.length) {
+            return undefined;
+          }
+          const coverage = this.computeCoverage(candles, timeframe);
+          const key = this.buildProbeKey(symbol, timeframe);
+          const mock = this.mockedProbes.has(key);
+          return {
+            symbol,
+            broker: query.broker ?? (mock ? 'Mock Broker' : 'Unknown'),
+            timeframe,
+            start: coverage.start,
+            end: coverage.end,
+            count: coverage.count,
+            coveragePct: coverage.coveragePct,
+            gapsPct: coverage.gapsPct,
+            sessions: '-',
+            tz: 'UTC',
+            updatedAt: new Date().toISOString(),
+            source: mock ? 'Mock' : 'API',
+          } as DataSeries;
+        })
+      )
+    );
+
+    return forkJoin(requests).pipe(
+      map(list => list.filter((item): item is DataSeries => !!item)),
+      map(list => (list.length > 0 ? list : MOCK_SERIES))
+    );
+  }
+
+  private normalizeSeries(series: DataSeries[]): DataSeries[] {
+    return series.map(item => {
+      const normalized: DataSeries = {
+        symbol: item.symbol,
+        broker: item.broker,
+        timeframe: item.timeframe,
+        start: this.ensureIsoString(item.start),
+        end: this.ensureIsoString(item.end),
+        count: item.count ?? 0,
+        coveragePct: item.coveragePct ?? 0,
+        gapsPct: item.gapsPct ?? undefined,
+        sessions: item.sessions ?? '-',
+        tz: item.tz ?? 'UTC',
+        updatedAt: item.updatedAt ? this.ensureIsoString(item.updatedAt) : new Date().toISOString(),
+        datasetId: item.datasetId,
+        venue: item.venue,
+        source: item.source ?? 'API',
+      };
+
+      if ((!normalized.coveragePct || normalized.coveragePct <= 0) && normalized.start && normalized.end) {
+        const expected = this.estimateExpected(normalized.start, normalized.end, normalized.timeframe);
+        normalized.coveragePct = expected > 0 ? Number(((normalized.count / expected) * 100).toFixed(2)) : 0;
+      } else {
+        normalized.coveragePct = Number(normalized.coveragePct.toFixed(2));
+      }
+
+      if (normalized.gapsPct != null) {
+        normalized.gapsPct = Number(normalized.gapsPct.toFixed(2));
+      }
+
+      return normalized;
+    });
+  }
+
+  private estimateExpected(start: string, end: string, timeframe: string): number {
+    const frameMs = this.timeframeToMs(timeframe);
+    if (!frameMs) {
+      return 0;
+    }
+    const startMs = new Date(start).getTime();
+    const endMs = new Date(end).getTime();
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) {
+      return 0;
+    }
+    return Math.floor((endMs - startMs) / frameMs) + 1;
+  }
+
+  private ensureIsoString(value?: string): string {
+    if (!value) {
+      return '';
+    }
+    const ms = new Date(value).getTime();
+    if (Number.isNaN(ms)) {
+      return value;
+    }
+    return new Date(ms).toISOString();
+  }
+
+  private timeframeToMs(timeframe: string): number {
+    const match = timeframe?.match(/^(\d+)([smhdw])$/i);
+    if (!match) {
+      if (timeframe?.toLowerCase() === '1min') {
+        return 60 * 1000;
+      }
+      return 0;
+    }
+    const value = Number.parseInt(match[1], 10);
+    const unit = match[2].toLowerCase();
+    switch (unit) {
+      case 's':
+        return value * 1000;
+      case 'm':
+        return value * 60 * 1000;
+      case 'h':
+        return value * 60 * 60 * 1000;
+      case 'd':
+        return value * 24 * 60 * 60 * 1000;
+      case 'w':
+        return value * 7 * 24 * 60 * 60 * 1000;
+      default:
+        return 0;
+    }
+  }
+
+  private buildProbeKey(symbol: string, timeframe: string): string {
+    return `${symbol}__${timeframe}`;
+  }
+}
+

--- a/src/app/services/symbol.service.ts
+++ b/src/app/services/symbol.service.ts
@@ -1,0 +1,25 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { SymbolRef } from '../models/data-catalog.models';
+import { DEFAULT_SYMBOLS } from '../mocks/data-catalog.mocks';
+
+@Injectable({ providedIn: 'root' })
+export class SymbolService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = environment.apiUrl;
+
+  getAll(): Observable<SymbolRef[]> {
+    return this.http.get<SymbolRef[]>(`${this.apiUrl}/api/finance/symbols`).pipe(
+      tap(list => console.log('[SymbolService] list symbols', list?.length ?? 0)),
+      map(list => (Array.isArray(list) ? list : [])),
+      catchError(err => {
+        console.warn('[SymbolService] fallback to default symbols', err);
+        return of(DEFAULT_SYMBOLS);
+      })
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add shared data catalog models, mocks, and services with API fallbacks and ingestion routing
- implement a standalone data availability page featuring filters, availability table, details drawer, and ingestion workflow
- cover coverage calculations with unit tests and expose the page through the router

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: Angular CLI unavailable because npm install is blocked by 403 from registry)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d37f88c98832395c125b4dd519454)