### PR TITLE
style: align data availability and market analysis styling

### DIFF
--- a/src/app/components/market-analysis/market-analysis.page.html
+++ b/src/app/components/market-analysis/market-analysis.page.html
@@ -1,6 +1,5 @@
 <section class="market-analysis">
   <header class="market-analysis__header">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
     <form [formGroup]="analysisForm" class="analysis-form" (ngSubmit)="loadAnalysis()">
       <mat-form-field appearance="outline">

--- a/src/app/components/market-analysis/market-analysis.page.scss
+++ b/src/app/components/market-analysis/market-analysis.page.scss
@@ -39,6 +39,31 @@
   min-width: 220px;
   flex: 1;
   font-size: 1.05rem;
+  --mdc-outlined-text-field-container-shape: 14px;
+  --mdc-outlined-text-field-outline-color: rgba(15, 23, 42, 0.16);
+  --mdc-outlined-text-field-hover-outline-color: rgba(37, 99, 235, 0.9);
+  --mdc-outlined-text-field-focus-outline-color: rgba(37, 99, 235, 0.95);
+  --mat-mdc-form-field-label-text-color: rgba(15, 23, 42, 0.72);
+}
+
+.market-analysis__header mat-form-field .mat-mdc-form-field-flex {
+  min-height: 56px;
+  align-items: center;
+}
+
+.market-analysis__header mat-form-field .mat-mdc-text-field-wrapper {
+  border-radius: 14px;
+}
+
+.market-analysis__header mat-form-field .mat-mdc-form-field-infix {
+  padding: 0.75rem 0 0.35rem;
+}
+
+.market-analysis__header mat-form-field .mat-mdc-select-trigger,
+.market-analysis__header mat-form-field .mat-mdc-select-arrow-wrapper {
+  height: 100%;
+  display: flex;
+  align-items: center;
 }
 
 .market-analysis__header mat-label,
@@ -73,7 +98,7 @@
   width: 100%;
 }
 
-.mat-mdc-select-panel {
+:host ::ng-deep .mat-mdc-select-panel {
   background: #ffffff !important;
   color: #0f172a !important;
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.22) !important;
@@ -81,15 +106,17 @@
   font-size: 1rem !important;
 }
 
-.mat-mdc-option .mdc-list-item__primary-text {
+:host ::ng-deep .mat-mdc-option .mdc-list-item__primary-text {
   color: #0f172a !important;
   font-size: 1rem !important;
 }
 
-.mat-mdc-option.mdc-list-item--selected,
-.mat-mdc-option.mdc-list-item--activated,
-.mat-mdc-option:hover {
-  background: rgba(37, 99, 235, 0.12) !important;
+:host ::ng-deep .mat-mdc-option.mdc-list-item--selected,
+:host ::ng-deep .mat-mdc-option.mdc-list-item--activated,
+:host ::ng-deep .mat-mdc-option:hover {
+  background: #e0e7ff !important;
+  color: #1d4ed8 !important;
+  opacity: 1 !important;
 }
 
 .kpis {

--- a/src/app/components/market-analysis/market-analysis.page.scss
+++ b/src/app/components/market-analysis/market-analysis.page.scss
@@ -1,31 +1,42 @@
-/* --- HEADER centré avec style arrondi --- */
+:host {
+  display: block;
+  background: #f8fafc;
+  min-height: 100%;
+  padding: 1.75rem;
+  box-sizing: border-box;
+}
+
+.market-analysis {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
 .market-analysis__header {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  gap: 1.25rem;
+  padding: 2rem 2.5rem 1.75rem;
   text-align: center;
-
   background: #ffffff;
-  border-radius: 16px; /* coins arrondis */
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
-  padding: 2rem 3rem 1.75rem;
+  border-radius: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 14px 36px rgba(15, 23, 42, 0.12);
 }
 
-/* --- FORMULAIRE --- */
 .market-analysis__header .analysis-form {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 1.25rem 2rem;
   align-items: flex-end;
+  gap: 1.25rem 2rem;
   width: 100%;
-  max-width: 1200px; /* limite la largeur */
+  max-width: 1100px;
 }
 
-/* --- CHAMPS --- */
 .market-analysis__header mat-form-field {
-  min-width: 200px;
+  min-width: 220px;
   flex: 1;
   font-size: 1.05rem;
 }
@@ -36,85 +47,106 @@
   font-size: 1rem !important;
 }
 
-/* --- LISTE DÉROULANTE opaque + taille lisible --- */
-.mat-mdc-select-panel {
-  background: #ffffff !important;
-  color: #111827 !important;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25) !important;
-  border-radius: 10px !important; /* arrondi du menu déroulant */
-  font-size: 1rem !important;
-}
-
-.mat-mdc-option .mdc-list-item__primary-text {
-  color: #111827 !important;
-  font-size: 1rem !important;
-}
-
-/* Survol option */
-.mat-mdc-option.mdc-list-item--selected,
-.mat-mdc-option.mdc-list-item--activated,
-.mat-mdc-option:hover {
-  background: rgba(99, 102, 241, 0.1) !important;
-}
-
-/* --- BOUTON --- */
 .market-analysis__header button[mat-flat-button] {
-  background-color: #6366f1;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(79, 70, 229, 0.9));
   color: #ffffff;
   height: 56px;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
-  border-radius: 10px; /* bouton arrondi */
+  border-radius: 12px;
   font-size: 1.05rem;
-  padding: 0 1.5rem;
+  font-weight: 600;
+  padding: 0 1.75rem;
+  box-shadow: 0 14px 30px rgba(37, 99, 235, 0.28);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-/* --- Progress bar --- */
+.market-analysis__header button[mat-flat-button]:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(37, 99, 235, 0.32);
+}
+
 .market-analysis__header mat-progress-bar {
   margin-top: 0.75rem;
+  width: 100%;
 }
 
-/* --- Responsive --- */
-@media (max-width: 768px) {
-  .market-analysis__header {
-    padding: 1.5rem;
-  }
-
-  .market-analysis__header .analysis-form {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .market-analysis__header mat-form-field {
-    width: 100%;
-  }
+.mat-mdc-select-panel {
+  background: #ffffff !important;
+  color: #0f172a !important;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.22) !important;
+  border-radius: 12px !important;
+  font-size: 1rem !important;
 }
 
-/* KPIs */
+.mat-mdc-option .mdc-list-item__primary-text {
+  color: #0f172a !important;
+  font-size: 1rem !important;
+}
+
+.mat-mdc-option.mdc-list-item--selected,
+.mat-mdc-option.mdc-list-item--activated,
+.mat-mdc-option:hover {
+  background: rgba(37, 99, 235, 0.12) !important;
+}
+
 .kpis {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
 }
 
 .kpi-card {
-  background: linear-gradient(
-      135deg,
-      rgba(99, 102, 241, 0.06),
-      rgba(59, 130, 246, 0.06)
-  );
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.06), rgba(79, 70, 229, 0.05));
+}
+
+.kpi-card mat-card-header {
+  align-items: center;
+}
+
+.kpi-card mat-card-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.mock-chip {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+  padding: 0 0.75rem;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  background: rgba(99, 102, 241, 0.1);
+  color: #4f46e5;
+  font-weight: 600;
+}
+
+.kpi-card mat-card-content {
+  display: flex;
+  justify-content: center;
+  padding-top: 0.25rem;
 }
 
 .kpi-value {
-  font-size: 1.75rem;
+  font-size: 1.9rem;
   font-weight: 700;
-  color: #111827;
+  color: #0f172a;
 }
 
-/* Contenu principal */
 .content-card {
-  padding: 1.5rem;
+  padding: 1.75rem;
+  border-radius: 20px;
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.12);
 }
 
 .tab-header {
@@ -122,13 +154,14 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 1rem;
-}
+  margin-bottom: 1.25rem;
 
-.mock-chip {
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.05em;
+  h3 {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #0f172a;
+  }
 }
 
 .seasonality-charts {
@@ -143,7 +176,7 @@
 }
 
 .heatmap-container {
-  margin-top: 1.5rem;
+  margin-top: 1.75rem;
 }
 
 .stats-table-wrapper {
@@ -158,16 +191,28 @@
 .stats-table th,
 .stats-table td {
   text-align: left;
-  padding: 0.75rem 0.5rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.85rem 0.75rem;
+}
+
+.stats-table th {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #475569;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.stats-table tbody tr:not(:last-child) td {
+  border-bottom: 1px solid rgba(226, 232, 240, 0.75);
 }
 
 .empty-state {
-  color: rgba(75, 85, 99, 0.9);
+  color: #94a3b8;
   font-style: italic;
+  text-align: center;
+  padding: 1rem 0;
 }
 
-/* Filtres */
 .filters-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -177,18 +222,34 @@
 .filter-card {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.1);
+}
+
+.filter-card mat-card-header {
+  align-items: center;
+}
+
+.filter-card mat-card-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
 }
 
 .filter-category {
   font-weight: 600;
-  color: #111827;
+  color: #475569;
   margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .filter-description {
   margin-bottom: 0.75rem;
-  color: #4b5563;
+  color: #64748b;
+  line-height: 1.5;
 }
 
 .filter-metrics {
@@ -200,12 +261,14 @@
 .metric span {
   font-size: 0.75rem;
   text-transform: uppercase;
-  color: #9ca3af;
+  color: #94a3b8;
+  letter-spacing: 0.04em;
 }
 
 .metric strong {
   display: block;
-  margin-top: 0.25rem;
+  margin-top: 0.3rem;
+  color: #0f172a;
 }
 
 .sparkline {
@@ -223,14 +286,65 @@
   stroke-width: 2;
 }
 
+.source-chip {
+  border-radius: 999px;
+  padding: 0 0.75rem;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
 .source-chip.java {
-  background-color: rgba(124, 58, 237, 0.1);
+  background: rgba(124, 58, 237, 0.12);
   color: #6d28d9;
 }
 
 .source-chip.py {
-  background-color: rgba(37, 99, 235, 0.1);
+  background: rgba(37, 99, 235, 0.12);
   color: #2563eb;
 }
 
+@media (max-width: 1024px) {
+  .market-analysis__header {
+    padding: 1.75rem 1.5rem;
+  }
 
+  .market-analysis__header .analysis-form {
+    gap: 1rem 1.25rem;
+  }
+}
+
+@media (max-width: 768px) {
+  :host {
+    padding: 1.25rem;
+  }
+
+  .market-analysis__header {
+    text-align: left;
+    align-items: stretch;
+  }
+
+  .market-analysis__header .analysis-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .market-analysis__header mat-form-field {
+    width: 100%;
+  }
+
+  .kpis {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+}

--- a/src/app/pages/data-availability/data-availability.page.scss
+++ b/src/app/pages/data-availability/data-availability.page.scss
@@ -281,8 +281,46 @@ tbody tr:not(:last-child) td {
 }
 
 .mat-mdc-paginator {
-  border-top: 1px solid rgba(226, 232, 240, 0.8);
-  padding: 0.5rem 1rem;
+  margin-top: 0.75rem;
+  padding: 0.35rem 1.5rem;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+
+  .mat-mdc-paginator-outer-container {
+    min-height: 60px;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .mat-mdc-paginator-page-size-select {
+    margin-left: 0.75rem;
+
+    .mat-mdc-form-field-flex {
+      min-height: 48px;
+      align-items: center;
+    }
+
+    .mat-mdc-text-field-wrapper {
+      border-radius: 12px;
+    }
+
+    .mat-mdc-select-trigger,
+    .mat-mdc-select-arrow-wrapper {
+      height: 100%;
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  .mat-mdc-paginator-range-actions {
+    gap: 0.5rem;
+
+    button {
+      border-radius: 10px;
+    }
+  }
 }
 
 .details-drawer {
@@ -459,6 +497,35 @@ tbody tr:not(:last-child) td {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1.25rem 1.5rem;
+
+  mat-form-field {
+    width: 100%;
+    --mdc-outlined-text-field-container-shape: 14px;
+    --mdc-outlined-text-field-outline-color: rgba(15, 23, 42, 0.16);
+    --mdc-outlined-text-field-hover-outline-color: rgba(37, 99, 235, 0.9);
+    --mdc-outlined-text-field-focus-outline-color: rgba(37, 99, 235, 0.95);
+    --mat-mdc-form-field-label-text-color: rgba(15, 23, 42, 0.72);
+  }
+
+  mat-form-field .mat-mdc-form-field-flex {
+    min-height: 56px;
+    align-items: center;
+  }
+
+  mat-form-field .mat-mdc-text-field-wrapper {
+    border-radius: 14px;
+  }
+
+  mat-form-field .mat-mdc-form-field-infix {
+    padding: 0.75rem 0 0.35rem;
+  }
+
+  mat-form-field .mat-mdc-select-trigger,
+  mat-form-field .mat-mdc-select-arrow-wrapper {
+    height: 100%;
+    display: flex;
+    align-items: center;
+  }
 }
 
 .date-row {

--- a/src/app/pages/data-availability/data-availability.page.scss
+++ b/src/app/pages/data-availability/data-availability.page.scss
@@ -6,6 +6,15 @@
   box-sizing: border-box;
 }
 
+
+:host ::ng-deep mat-horizontal-stepper .mat-horizontal-stepper-header-container {
+  padding-bottom: 12px;
+}
+
+:host ::ng-deep mat-horizontal-stepper .mat-horizontal-content-container {
+  padding-top: 8px;
+}
+
 .header-toolbar {
   position: sticky;
   top: 1.75rem;

--- a/src/app/pages/data-availability/data-availability.page.scss
+++ b/src/app/pages/data-availability/data-availability.page.scss
@@ -55,6 +55,31 @@
 
   mat-form-field {
     width: 100%;
+    --mdc-outlined-text-field-container-shape: 14px;
+    --mdc-outlined-text-field-outline-color: rgba(15, 23, 42, 0.16);
+    --mdc-outlined-text-field-hover-outline-color: rgba(37, 99, 235, 0.9);
+    --mdc-outlined-text-field-focus-outline-color: rgba(37, 99, 235, 0.95);
+    --mat-mdc-form-field-label-text-color: rgba(15, 23, 42, 0.72);
+  }
+
+  mat-form-field .mat-mdc-form-field-flex {
+    min-height: 56px;
+    align-items: center;
+  }
+
+  mat-form-field .mat-mdc-text-field-wrapper {
+    border-radius: 14px;
+  }
+
+  mat-form-field .mat-mdc-form-field-infix {
+    padding: 0.75rem 0 0.35rem;
+  }
+
+  mat-form-field .mat-mdc-select-trigger,
+  mat-form-field .mat-mdc-select-arrow-wrapper {
+    height: 100%;
+    display: flex;
+    align-items: center;
   }
 
   .symbol-field {
@@ -88,6 +113,27 @@
       color: #64748b;
     }
   }
+}
+
+:host ::ng-deep .mat-mdc-autocomplete-panel,
+:host ::ng-deep .mat-mdc-select-panel {
+  background: #ffffff !important;
+  color: #0f172a !important;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.22) !important;
+  border-radius: 12px !important;
+  font-size: 0.95rem !important;
+}
+
+:host ::ng-deep .mat-mdc-option .mdc-list-item__primary-text {
+  color: #0f172a !important;
+}
+
+:host ::ng-deep .mat-mdc-option.mdc-list-item--selected,
+:host ::ng-deep .mat-mdc-option.mdc-list-item--activated,
+:host ::ng-deep .mat-mdc-option:hover {
+  background: #e0e7ff !important;
+  color: #1d4ed8 !important;
+  opacity: 1 !important;
 }
 
 .drawer-container {

--- a/src/app/pages/data-availability/data-availability.page.scss
+++ b/src/app/pages/data-availability/data-availability.page.scss
@@ -1,31 +1,64 @@
+:host {
+  display: block;
+  background: #f8fafc;
+  min-height: 100%;
+  padding: 1.75rem;
+  box-sizing: border-box;
+}
+
 .header-toolbar {
   position: sticky;
-  top: 0;
+  top: 1.75rem;
   z-index: 5;
   display: flex;
   align-items: center;
-  padding: 0 1rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  margin-bottom: 1.5rem;
 
   .title {
-    font-size: 1.2rem;
+    font-size: 1.3rem;
     font-weight: 600;
+    letter-spacing: 0.01em;
   }
 
   .spacer {
     flex: 1;
   }
+
+  button[mat-icon-button] {
+    color: inherit;
+    transition: transform 0.2s ease, color 0.2s ease;
+
+    &:hover {
+      color: #2563eb;
+      transform: translateY(-1px);
+    }
+  }
 }
 
 .filters {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-  padding: 1.5rem 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
   align-items: end;
-  background-color: var(--mat-sys-surface-container-low, #f8f9fb);
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+
+  mat-form-field {
+    width: 100%;
+  }
 
   .symbol-field {
-    min-width: 220px;
+    min-width: 240px;
   }
 
   .search-field {
@@ -43,14 +76,16 @@
   .symbol-option {
     display: flex;
     flex-direction: column;
+    gap: 0.1rem;
 
     .ticker {
       font-weight: 600;
+      color: #0f172a;
     }
 
     .name {
       font-size: 0.85rem;
-      opacity: 0.7;
+      color: #64748b;
     }
   }
 }
@@ -58,101 +93,133 @@
 .drawer-container {
   display: flex;
   min-height: 520px;
+  margin: 0 -0.25rem;
 }
 
 .table-wrapper {
   position: relative;
-  margin: 0 1rem;
-  background: #fff;
-  border-radius: 8px;
+  margin: 0 0.25rem;
+  background: #ffffff;
+  border-radius: 16px;
   overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 14px 36px rgba(15, 23, 42, 0.1);
+  padding-bottom: 1rem;
 }
 
 .table-wrapper.loading {
-  opacity: 0.5;
+  opacity: 0.55;
 }
 
 .table-wrapper table {
   width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.9rem 1.25rem;
+  color: #0f172a;
+  font-size: 0.95rem;
+}
+
+th {
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #475569;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+tbody tr:not(:last-child) td {
+  border-bottom: 1px solid rgba(226, 232, 240, 0.75);
 }
 
 .cell-main {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.65rem;
 }
 
 .symbol {
   font-weight: 600;
+  color: #0f172a;
 }
 
 .mock-badge {
-  background-color: #ffcc80;
-  color: #5d4037;
-  padding: 0.1rem 0.4rem;
+  background: rgba(250, 204, 21, 0.22);
+  color: #854d0e;
+  padding: 0.2rem 0.55rem;
   border-radius: 999px;
   font-size: 0.7rem;
+  font-weight: 600;
   text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .broker-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.2rem 0.6rem;
+  padding: 0.3rem 0.7rem;
   border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
 }
 
 .broker-binance {
-  background: #f7d34b;
-  color: #2f2f2f;
+  background: rgba(250, 204, 21, 0.22);
+  color: #854d0e;
 }
 
 .broker-mexc {
-  background: #1ba784;
-  color: #fff;
+  background: rgba(16, 185, 129, 0.18);
+  color: #047857;
 }
 
 .broker-ibkr {
-  background: #1976d2;
-  color: #fff;
+  background: rgba(37, 99, 235, 0.18);
+  color: #1d4ed8;
 }
 
 .broker-csv {
-  background: #757575;
-  color: #fff;
+  background: rgba(100, 116, 139, 0.22);
+  color: #334155;
 }
 
 .broker-generic {
-  background: #e0e0e0;
-  color: #424242;
+  background: rgba(148, 163, 184, 0.28);
+  color: #1e293b;
 }
 
 .source-chip {
   display: inline-flex;
   align-items: center;
-  padding: 0.1rem 0.5rem;
+  padding: 0.2rem 0.6rem;
   border-radius: 999px;
-  background: rgba(33, 33, 33, 0.08);
+  background: rgba(15, 23, 42, 0.08);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #0f172a;
 }
 
 .source-chip.source-mock {
-  background: rgba(229, 57, 53, 0.15);
-  color: #b71c1c;
+  background: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
 }
 
 .low-coverage {
-  color: #d32f2f;
+  color: #b91c1c;
   font-weight: 600;
 }
 
 .actions-cell button + button {
-  margin-left: 0.5rem;
+  margin-left: 0.35rem;
 }
 
 .loading-overlay,
@@ -160,67 +227,105 @@
 .drawer-loading {
   position: absolute;
   inset: 0;
-  background: rgba(255, 255, 255, 0.65);
+  background: rgba(255, 255, 255, 0.72);
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.loading-overlay {
   backdrop-filter: blur(2px);
 }
 
 .mat-mdc-paginator {
-  border-top: 1px solid rgba(0, 0, 0, 0.05);
+  border-top: 1px solid rgba(226, 232, 240, 0.8);
+  padding: 0.5rem 1rem;
 }
 
 .details-drawer {
   width: min(420px, 90vw);
-  padding: 1.5rem;
+  padding: 1.75rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
+  background: #ffffff;
+  border-left: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .drawer-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
+
+  h3 {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #0f172a;
+  }
 }
 
 .drawer-content {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
+
+  h4,
+  h5 {
+    margin: 0;
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  p {
+    margin: 0;
+    color: #475569;
+    font-size: 0.95rem;
+  }
 }
 
 .coverage-summary {
   display: flex;
   gap: 1.5rem;
+  flex-wrap: wrap;
 
   .metric {
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    background: rgba(37, 99, 235, 0.08);
 
     .label {
       font-size: 0.8rem;
-      opacity: 0.7;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #2563eb;
     }
 
     .value {
       font-size: 1.2rem;
       font-weight: 600;
+      color: #0f172a;
     }
   }
 }
 
 .histogram {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  h5 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #0f172a;
+  }
+
   .hist-bars {
     display: grid;
     grid-template-columns: repeat(30, minmax(4px, 1fr));
-    gap: 3px;
+    gap: 4px;
     align-items: end;
     height: 120px;
   }
@@ -228,17 +333,17 @@
   .hist-bar {
     position: relative;
     width: 100%;
-    background: linear-gradient(180deg, #64b5f6, #1e88e5);
-    border-radius: 3px;
+    background: linear-gradient(180deg, rgba(37, 99, 235, 0.9), rgba(14, 165, 233, 0.9));
+    border-radius: 6px;
 
     .tooltip {
       position: absolute;
       bottom: 100%;
       left: 50%;
-      transform: translate(-50%, -6px);
-      background: rgba(33, 33, 33, 0.85);
-      color: #fff;
-      padding: 0.2rem 0.4rem;
+      transform: translate(-50%, -8px);
+      background: rgba(15, 23, 42, 0.92);
+      color: #ffffff;
+      padding: 0.2rem 0.45rem;
       border-radius: 4px;
       font-size: 0.7rem;
       white-space: nowrap;
@@ -254,6 +359,17 @@
 }
 
 .gaps {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  h5 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #0f172a;
+  }
+
   .gap-list {
     display: flex;
     flex-direction: column;
@@ -264,30 +380,39 @@
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
-    background: rgba(33, 33, 33, 0.04);
-    border-radius: 6px;
-    padding: 0.5rem 0.75rem;
+    background: rgba(148, 163, 184, 0.15);
+    border-radius: 12px;
+    padding: 0.75rem 1rem;
 
     .period {
       font-weight: 600;
+      color: #0f172a;
     }
 
     .missing {
       font-size: 0.85rem;
-      opacity: 0.75;
+      color: #475569;
     }
+  }
+
+  p {
+    margin: 0;
+    color: #94a3b8;
   }
 }
 
 .range-card {
-  margin: 1.5rem 1rem 2rem;
-  padding: 1rem 1.5rem 2rem;
+  margin: 2rem 0 0;
+  padding: 1.5rem 1.75rem 2.25rem;
+  border-radius: 16px;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .step-content {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem 1.5rem;
+  gap: 1.25rem 1.5rem;
 }
 
 .date-row {
@@ -300,31 +425,62 @@
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
-  margin-top: 0.5rem;
+  margin-top: 0.75rem;
 }
 
 .summary-step {
   position: relative;
   gap: 0.75rem;
+
+  h4 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  p {
+    margin: 0;
+    color: #475569;
+    font-size: 0.95rem;
+  }
+}
+
+@media (max-width: 1200px) {
+  .filters {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
 }
 
 @media (max-width: 960px) {
-  .filters {
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  :host {
+    padding: 1.25rem;
+  }
+
+  .header-toolbar {
+    top: 1.25rem;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
   }
 
   .drawer-container {
     flex-direction: column;
+    margin: 0;
   }
 
   .details-drawer {
     width: 100%;
     position: static;
+    border-left: none;
+    border-top: 1px solid rgba(15, 23, 42, 0.08);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
+  *,
+  *::before,
+  *::after {
     transition-duration: 0.001ms !important;
     animation-duration: 0.001ms !important;
   }

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,8 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- refresh the data availability page layout with the shared light card styling, spacing, and badges
- restyle the market analysis dashboard to reuse the same palette, card shadows, and typography as the rest of the app

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f3eb5ccf08323a0d82ec315d639ea)