### PR TITLE
feat: connect data availability page to data import jobs

### DIFF
--- a/src/app/mocks/data-catalog.mocks.ts
+++ b/src/app/mocks/data-catalog.mocks.ts
@@ -1,4 +1,4 @@
-import { Candle, DataSeries, SaveResult, SymbolRef } from '../models/data-catalog.models';
+import { Candle, DataSeries, SymbolRef } from '../models/data-catalog.models';
 
 export const DEFAULT_SYMBOLS: SymbolRef[] = [
   { ticker: 'EURUSD', name: 'Euro / US Dollar', market: 'FX' },
@@ -197,8 +197,6 @@ export const MOCK_SERIES: DataSeries[] = [
     source: 'Mock'
   }
 ];
-
-export const MOCK_SAVE_OK: SaveResult = { ok: true, mock: true, message: 'Saved (mock)' };
 
 export function getMockCandles(symbol: string, timeframe: string): Candle[] {
   const existing = MOCK_CANDLES[symbol]?.[timeframe];

--- a/src/app/models/data-catalog.models.ts
+++ b/src/app/models/data-catalog.models.ts
@@ -11,6 +11,7 @@ export type SessionType = '24/7' | 'RTH' | 'Globex' | '-';
 export type DataSourceType = 'API' | 'CSV' | 'Mock';
 export type ConflictPolicy = 'merge' | 'overwrite' | 'skip';
 export type RolloverPolicy = 'date' | 'volume';
+export type DataImportJobStatus = 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED' | 'CANCELLED' | 'UNKNOWN';
 
 export interface DataSeries {
   symbol: string;
@@ -51,16 +52,42 @@ export interface SaveRangeRequest {
   rollover?: RolloverPolicy;
 }
 
-export interface SaveResult {
-  ok: boolean;
-  mock?: boolean;
-  message?: string;
-}
-
 export interface SymbolRef {
   id?: string;
   ticker: string;
   name?: string;
   market?: string;
+}
+
+export interface DataImportJobRequest {
+  broker: string;
+  symbol: string;
+  timeframe: string;
+  startDate: string;
+  endDate: string;
+  sourceType: string;
+  venue?: string;
+  timezone?: string;
+  conflictPolicy?: ConflictPolicy;
+  rollover?: RolloverPolicy;
+}
+
+export interface DataImportJob {
+  id: string;
+  broker: string;
+  symbol: string;
+  timeframe: string;
+  startDate: string;
+  endDate: string;
+  sourceType: string;
+  venue?: string;
+  timezone?: string;
+  conflictPolicy?: ConflictPolicy;
+  rollover?: RolloverPolicy;
+  status?: DataImportJobStatus;
+  progress?: number;
+  message?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 

--- a/src/app/pages/data-availability/data-availability.page.ts
+++ b/src/app/pages/data-availability/data-availability.page.ts
@@ -22,10 +22,18 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDividerModule } from '@angular/material/divider';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { debounceTime, map, startWith } from 'rxjs/operators';
+import { debounceTime, finalize, map, startWith } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { DataCatalogService } from '../../services/data-catalog.service';
-import { DataSeries, SaveRangeRequest, SaveResult, SymbolRef, Candle } from '../../models/data-catalog.models';
+import {
+  Candle,
+  DataImportJob,
+  DataImportJobRequest,
+  DataSeries,
+  SaveRangeRequest,
+  SymbolRef,
+} from '../../models/data-catalog.models';
+import { DataImportService } from '../../services/data-import.service';
 import { SymbolService } from '../../services/symbol.service';
 import { DEFAULT_SYMBOLS } from '../../mocks/data-catalog.mocks';
 
@@ -74,6 +82,7 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
   private readonly fb = inject(FormBuilder);
   private readonly snackBar = inject(MatSnackBar);
   private readonly dataCatalog = inject(DataCatalogService);
+  private readonly dataImport = inject(DataImportService);
   private readonly symbolService = inject(SymbolService);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -380,16 +389,23 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
     };
 
     this.savingRange.set(true);
-    this.dataCatalog
-      .saveRange(payload)
-      .pipe(takeUntilDestroyed(this.destroyRef))
+    const jobRequest = this.buildJobRequest(payload);
+    this.dataImport
+      .createJob(jobRequest)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.savingRange.set(false))
+      )
       .subscribe({
-        next: result => this.handleSaveResult(result, payload, scanAfter),
+        next: job => this.handleJobCreated(job, payload, scanAfter),
         error: err => {
-          console.error('Save range failed', err);
-          this.handleSaveResult({ ok: true, mock: true, message: 'Saved (mock fallback)' }, payload, scanAfter);
+          console.error('Data import job creation failed', err);
+          const mockJob = this.buildMockJob(payload);
+          this.handleJobCreated(mockJob, payload, scanAfter, {
+            mock: true,
+            messageOverride: 'Backend indisponible, job simulé créé.',
+          });
         },
-        complete: () => this.savingRange.set(false),
       });
   }
 
@@ -399,34 +415,111 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
     this.scanAfterSave.setValue(true);
   }
 
-  private handleSaveResult(result: SaveResult, payload: SaveRangeRequest, scanAfter: boolean): void {
-    this.savingRange.set(false);
-    const message = result.mock ? result.message ?? 'Sauvegarde simulée' : result.message ?? 'Sauvegarde déclenchée';
-    this.snackBar.open(message, 'Fermer', { duration: 4000 });
+  private handleJobCreated(
+    job: DataImportJob,
+    payload: SaveRangeRequest,
+    scanAfter: boolean,
+    options?: { mock?: boolean; messageOverride?: string }
+  ): void {
+    const isMock = options?.mock ?? false;
+    const statusLabel = this.formatJobStatus(job.status);
+    let message = options?.messageOverride;
 
-    if (!result.ok) {
-      return;
+    if (!message) {
+      const prefix = isMock ? "Job d'import simulé" : "Job d'import créé";
+      message = `${prefix} (#${job.id}) — statut ${statusLabel}`;
+      if (!isMock && scanAfter) {
+        message = `${message} — Scanner les gaps une fois le job terminé.`;
+      }
     }
+
+    this.snackBar.open(message, 'Fermer', { duration: 5000 });
 
     const newSeries: DataSeries = {
       symbol: payload.symbol,
       broker: payload.broker,
       timeframe: payload.timeframe,
-      start: payload.start,
-      end: payload.end,
+      start: job.startDate || payload.start,
+      end: job.endDate || payload.end,
       count: 0,
       coveragePct: 0,
       sessions: '-',
-      tz: payload.timezone ?? 'UTC',
-      updatedAt: new Date().toISOString(),
-      source: result.mock ? 'Mock' : payload.source,
+      tz: job.timezone || payload.timezone || 'UTC',
+      updatedAt: job.updatedAt || job.createdAt || new Date().toISOString(),
+      source: isMock ? 'Mock' : this.normalizeSourceType(job.sourceType ?? payload.source),
+      venue: job.venue || payload.venue,
     };
 
     this.upsertSeries(newSeries);
 
-    if (scanAfter) {
+    if (scanAfter && isMock) {
       this.scanGaps(newSeries);
     }
+  }
+
+  private buildJobRequest(payload: SaveRangeRequest): DataImportJobRequest {
+    return {
+      broker: payload.broker,
+      symbol: payload.symbol,
+      timeframe: payload.timeframe,
+      startDate: payload.start,
+      endDate: payload.end,
+      sourceType: payload.source,
+      venue: payload.venue || undefined,
+      timezone: payload.timezone || undefined,
+      conflictPolicy: payload.conflictPolicy,
+      rollover: payload.rollover,
+    };
+  }
+
+  private buildMockJob(payload: SaveRangeRequest): DataImportJob {
+    const now = new Date().toISOString();
+    return {
+      id: `mock-${Date.now()}`,
+      broker: payload.broker,
+      symbol: payload.symbol,
+      timeframe: payload.timeframe,
+      startDate: payload.start,
+      endDate: payload.end,
+      sourceType: payload.source,
+      venue: payload.venue,
+      timezone: payload.timezone,
+      conflictPolicy: payload.conflictPolicy,
+      rollover: payload.rollover,
+      status: 'UNKNOWN',
+      progress: 0,
+      message: 'Mock job (fallback)',
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  private formatJobStatus(status?: DataImportJob['status']): string {
+    switch (status) {
+      case 'PENDING':
+        return 'En attente';
+      case 'RUNNING':
+        return 'En cours';
+      case 'COMPLETED':
+        return 'Terminé';
+      case 'FAILED':
+        return 'Échec';
+      case 'CANCELLED':
+        return 'Annulé';
+      default:
+        return 'Inconnu';
+    }
+  }
+
+  private normalizeSourceType(source?: string): DataSeries['source'] {
+    const normalized = (source ?? '').toUpperCase();
+    if (normalized === 'CSV') {
+      return 'CSV';
+    }
+    if (normalized === 'MOCK') {
+      return 'Mock';
+    }
+    return 'API';
   }
 
   private upsertSeries(series: DataSeries): void {

--- a/src/app/services/data-catalog.service.ts
+++ b/src/app/services/data-catalog.service.ts
@@ -7,11 +7,9 @@ import {
   Candle,
   CoverageInfo,
   DataSeries,
-  SaveRangeRequest,
-  SaveResult,
   SymbolRef,
 } from '../models/data-catalog.models';
-import { DEFAULT_SYMBOLS, MOCK_SAVE_OK, MOCK_SERIES, getMockCandles } from '../mocks/data-catalog.mocks';
+import { DEFAULT_SYMBOLS, MOCK_SERIES, getMockCandles } from '../mocks/data-catalog.mocks';
 
 @Injectable({ providedIn: 'root' })
 export class DataCatalogService {
@@ -115,56 +113,6 @@ export class DataCatalogService {
           );
         })
       );
-  }
-
-  saveRange(req: SaveRangeRequest): Observable<SaveResult> {
-    const broker = (req.broker ?? '').toLowerCase();
-
-    if (broker.includes('binance')) {
-      const params = new HttpParams()
-        .set('symbol', req.symbol)
-        .set('interval', req.timeframe)
-        .set('startDate', req.start)
-        .set('endDate', req.end);
-      return this.http.get(`${this.apiUrl}/api/finance/charts/binance/historical-range`, { params }).pipe(
-        map(() => ({ ok: true, mock: false, message: 'Binance range requested' } as SaveResult)),
-        catchError(err => {
-          console.warn('[DataCatalogService] binance range fallback', err);
-          return of({ ...MOCK_SAVE_OK });
-        })
-      );
-    }
-
-    if (req.source === 'CSV') {
-      const body = {
-        symbol: req.symbol,
-        timeframe: req.timeframe,
-        startDate: req.start,
-        endDate: req.end,
-        timezone: req.timezone,
-        venue: req.venue,
-        conflictPolicy: req.conflictPolicy,
-        rollover: req.rollover,
-      };
-      const endpoint = broker.includes('databento') || broker.includes('cme')
-        ? `${this.apiUrl}/api/finance/charts/load-csv/cme`
-        : `${this.apiUrl}/api/finance/charts/load-csv/tradingview`;
-      return this.http.post(endpoint, body).pipe(
-        map(() => ({ ok: true, mock: false, message: 'CSV ingestion submitted' } as SaveResult)),
-        catchError(err => {
-          console.warn('[DataCatalogService] csv ingestion fallback', err);
-          return of({ ...MOCK_SAVE_OK });
-        })
-      );
-    }
-
-    if (broker.includes('ibkr') || broker.includes('mexc')) {
-      console.warn('[DataCatalogService] broker not yet supported, returning mock');
-      return of({ ...MOCK_SAVE_OK });
-    }
-
-    console.warn('[DataCatalogService] generic save fallback');
-    return of({ ...MOCK_SAVE_OK });
   }
 
   private buildSeriesFromProbes(query: {

--- a/src/app/services/data-import.service.ts
+++ b/src/app/services/data-import.service.ts
@@ -1,0 +1,67 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+import { environment } from '../../environments/environment';
+import {
+  DataImportJob,
+  DataImportJobRequest,
+  DataImportJobStatus,
+} from '../models/data-catalog.models';
+
+@Injectable({ providedIn: 'root' })
+export class DataImportService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = environment.apiUrl;
+
+  createJob(request: DataImportJobRequest): Observable<DataImportJob> {
+    return this.http.post<DataImportJob>(`${this.apiUrl}/api/data-import/jobs`, request).pipe(
+      map(response => this.normalizeJob(response)),
+      catchError(err => {
+        console.error('[DataImportService] createJob failed', err);
+        return throwError(() => err);
+      })
+    );
+  }
+
+  getJob(id: string): Observable<DataImportJob> {
+    return this.http
+      .get<DataImportJob>(`${this.apiUrl}/api/data-import/jobs/${id}`)
+      .pipe(map(response => this.normalizeJob(response)));
+  }
+
+  private normalizeJob(job: DataImportJob): DataImportJob {
+    const ensureIso = (value?: string) => {
+      if (!value) {
+        return value;
+      }
+      const ms = new Date(value).getTime();
+      return Number.isNaN(ms) ? value : new Date(ms).toISOString();
+    };
+
+    return {
+      ...job,
+      startDate: ensureIso(job.startDate) ?? '',
+      endDate: ensureIso(job.endDate) ?? '',
+      createdAt: ensureIso(job.createdAt),
+      updatedAt: ensureIso(job.updatedAt),
+      status: this.normalizeStatus(job.status),
+      progress: job.progress ?? 0,
+    };
+  }
+
+  private normalizeStatus(status?: string): DataImportJobStatus {
+    const normalized = (status ?? '').toUpperCase();
+    switch (normalized) {
+      case 'PENDING':
+      case 'RUNNING':
+      case 'COMPLETED':
+      case 'FAILED':
+      case 'CANCELLED':
+        return normalized;
+      default:
+        return 'UNKNOWN';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add shared models and a dedicated service for data import jobs
- update the data availability page to create import jobs via the new backend and keep a mock fallback
- remove the legacy saveRange path and unused mocks now that jobs are handled by the new controller

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9213061c8323bdef692bfe0378ba)