### PR TITLE
feat: enable universe imports from data availability page

### DIFF
--- a/src/app/pages/data-availability/data-availability.page.html
+++ b/src/app/pages/data-availability/data-availability.page.html
@@ -242,7 +242,14 @@
   </mat-drawer>
 </mat-drawer-container>
 
-<mat-card class="range-card" aria-label="Formulaire de sauvegarde de plage">
+<section class="import-mode-toggle" aria-label="Mode d'import">
+  <mat-button-toggle-group [(ngModel)]="mode" (change)="onModeChange($event)" aria-label="Mode d'import">
+    <mat-button-toggle value="instrument">Instrument</mat-button-toggle>
+    <mat-button-toggle value="universe">Univers</mat-button-toggle>
+  </mat-button-toggle-group>
+</section>
+
+<mat-card class="range-card" aria-label="Formulaire de sauvegarde de plage" *ngIf="mode === 'instrument'">
   <mat-horizontal-stepper>
     <mat-step [stepControl]="stepOne" label="Source">
       <form [formGroup]="stepOne" class="step-content">
@@ -368,4 +375,72 @@
       </div>
     </mat-step>
   </mat-horizontal-stepper>
+</mat-card>
+
+<mat-card class="universe-card" aria-label="Formulaire d'import d'univers" *ngIf="mode === 'universe'">
+  <div class="universe-form">
+    <mat-form-field appearance="outline">
+      <mat-label>Univers</mat-label>
+      <mat-select [(ngModel)]="selectedUniverseCode" name="universeCode">
+        <mat-option *ngFor="let u of universes" [value]="u.code">
+          {{ u.name }} ({{ u.type }} · {{ u.approxSize || '?' }} actifs)
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Broker</mat-label>
+      <mat-select [(ngModel)]="universeBroker" name="universeBroker">
+        <mat-option *ngFor="let broker of universeBrokers" [value]="broker">{{ broker }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Timeframe</mat-label>
+      <mat-select [(ngModel)]="universeTimeframe" name="universeTimeframe">
+        <mat-option *ngFor="let tf of timeframePresets" [value]="tf">{{ tf }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="date-range-field">
+      <mat-label>Période</mat-label>
+      <mat-date-range-input [rangePicker]="universeRangePicker">
+        <input matStartDate [(ngModel)]="universeStartDate" name="universeStart" placeholder="Début" />
+        <input matEndDate [(ngModel)]="universeEndDate" name="universeEnd" placeholder="Fin" />
+      </mat-date-range-input>
+      <mat-datepicker-toggle matIconSuffix [for]="universeRangePicker"></mat-datepicker-toggle>
+      <mat-date-range-picker #universeRangePicker></mat-date-range-picker>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Asset class (optionnel)</mat-label>
+      <input matInput [(ngModel)]="universeAssetClass" name="universeAssetClass" placeholder="EQUITY, CRYPTO..." />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Venue (optionnel)</mat-label>
+      <input matInput [(ngModel)]="universeVenue" name="universeVenue" placeholder="NYSE, BINANCEUS..." />
+    </mat-form-field>
+
+    <div class="universe-actions">
+      <button mat-raised-button color="primary" type="button" (click)="onImportUniverse()" [disabled]="universeImporting">
+        Lancer import univers
+      </button>
+      <mat-progress-spinner
+        *ngIf="universeImporting"
+        diameter="28"
+        mode="indeterminate"
+        class="universe-spinner"
+      ></mat-progress-spinner>
+      <button
+        mat-stroked-button
+        color="accent"
+        type="button"
+        *ngIf="showUniverseRefreshButton"
+        (click)="onRefreshAfterUniverse()"
+      >
+        Rafraîchir les séries
+      </button>
+    </div>
+  </div>
 </mat-card>

--- a/src/app/pages/data-availability/data-availability.page.scss
+++ b/src/app/pages/data-availability/data-availability.page.scss
@@ -124,6 +124,24 @@
   }
 }
 
+.import-mode-toggle {
+  margin: 2rem 0 1rem;
+  display: flex;
+  justify-content: flex-start;
+
+  ::ng-deep .mat-button-toggle-group {
+    border-radius: 999px;
+    overflow: hidden;
+    box-shadow: 0 8px 16px rgba(15, 23, 42, 0.12);
+  }
+
+  ::ng-deep .mat-button-toggle-button {
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+  }
+}
+
 :host ::ng-deep .mat-mdc-autocomplete-panel,
 :host ::ng-deep .mat-mdc-select-panel {
   background: #ffffff !important;
@@ -500,6 +518,46 @@ tbody tr:not(:last-child) td {
   border-radius: 16px;
   box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
   border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.universe-card {
+  margin: 2rem 0 0;
+  padding: 1.75rem;
+  border-radius: 16px;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: #ffffff;
+}
+
+.universe-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem 1.5rem;
+
+  mat-form-field {
+    width: 100%;
+    --mdc-outlined-text-field-container-shape: 14px;
+    --mdc-outlined-text-field-outline-color: rgba(15, 23, 42, 0.16);
+    --mdc-outlined-text-field-hover-outline-color: rgba(37, 99, 235, 0.9);
+    --mdc-outlined-text-field-focus-outline-color: rgba(37, 99, 235, 0.95);
+    --mat-mdc-form-field-label-text-color: rgba(15, 23, 42, 0.72);
+  }
+
+  .date-range-field .mat-mdc-form-field-infix {
+    min-height: 64px;
+  }
+}
+
+.universe-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.universe-spinner {
+  --mdc-circular-progress-active-indicator-color: #2563eb;
 }
 
 .step-content {

--- a/src/app/pages/data-availability/data-availability.page.ts
+++ b/src/app/pages/data-availability/data-availability.page.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { AfterViewInit, Component, DestroyRef, OnInit, ViewChild, inject, signal } from '@angular/core';
-import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -20,6 +20,7 @@ import { MatStepperModule } from '@angular/material/stepper';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatButtonToggleChange, MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatDividerModule } from '@angular/material/divider';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { debounceTime, finalize, map, startWith } from 'rxjs/operators';
@@ -35,6 +36,7 @@ import {
 } from '../../models/data-catalog.models';
 import { DataImportService } from '../../services/data-import.service';
 import { SymbolService } from '../../services/symbol.service';
+import { UniverseCatalog, UniverseImportRequest, UniverseService } from '../../services/universe.service';
 import { DEFAULT_SYMBOLS } from '../../mocks/data-catalog.mocks';
 
 interface HistogramBucket {
@@ -53,9 +55,11 @@ interface GapDetail {
   standalone: true,
   imports: [
     CommonModule,
+    FormsModule,
     ReactiveFormsModule,
     MatToolbarModule,
     MatButtonModule,
+    MatButtonToggleModule,
     MatIconModule,
     MatFormFieldModule,
     MatInputModule,
@@ -84,6 +88,7 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
   private readonly dataCatalog = inject(DataCatalogService);
   private readonly dataImport = inject(DataImportService);
   private readonly symbolService = inject(SymbolService);
+  private readonly universeService = inject(UniverseService);
   private readonly destroyRef = inject(DestroyRef);
 
   @ViewChild(MatPaginator) paginator?: MatPaginator;
@@ -150,10 +155,23 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
   readonly timeframePresets = ['1m', '5m', '15m', '1h', '4h', '1d', '1w'];
   readonly brokers = ['Binance', 'MEXC', 'IBKR', 'Databento CSV', 'CSV TradingView', 'Autre'];
   readonly marketTypes = ['FX', 'Crypto', 'Equity', 'ETF', 'Futures'];
+  readonly universeBrokers = ['IBKR', 'BINANCE', 'MEXC', 'BYBIT', 'KUCOIN'];
 
   symbols: SymbolRef[] = [];
   filteredSymbols$!: Observable<SymbolRef[]>;
   filteredStepSymbols$!: Observable<SymbolRef[]>;
+
+  mode: 'instrument' | 'universe' = 'instrument';
+  universes: UniverseCatalog[] = [];
+  selectedUniverseCode?: string;
+  universeBroker = 'IBKR';
+  universeTimeframe = '1d';
+  universeStartDate?: Date | null;
+  universeEndDate?: Date | null;
+  universeVenue?: string;
+  universeAssetClass?: string;
+  universeImporting = false;
+  showUniverseRefreshButton = false;
 
   private seriesCache: DataSeries[] = [];
   loading = signal(false);
@@ -172,6 +190,19 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
       .subscribe(list => {
         this.symbols = list.length ? list : DEFAULT_SYMBOLS;
         this.setupAutocomplete();
+      });
+
+    this.universeService
+      .getCatalog()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: universes => (this.universes = Array.isArray(universes) ? universes : []),
+        error: err => {
+          console.error('Failed to load universe catalog', err);
+          this.snackBar.open('Impossible de charger les univers disponibles, réessaie plus tard', 'Fermer', {
+            duration: 5000,
+          });
+        },
       });
 
     this.filtersForm.controls.columns.valueChanges
@@ -225,6 +256,59 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
     };
 
     this.refresh();
+  }
+
+  onModeChange(event: MatButtonToggleChange): void {
+    const selected = event.value as 'instrument' | 'universe';
+    this.mode = selected;
+    if (selected === 'instrument') {
+      this.showUniverseRefreshButton = false;
+    }
+  }
+
+  onImportUniverse(): void {
+    if (!this.selectedUniverseCode || !(this.universeStartDate instanceof Date) || !(this.universeEndDate instanceof Date)) {
+      this.snackBar.open('Univers et dates obligatoires', 'Fermer', { duration: 3000 });
+      return;
+    }
+
+    const request: UniverseImportRequest = {
+      code: this.selectedUniverseCode,
+      broker: this.universeBroker,
+      timeframe: this.universeTimeframe,
+      startDate: this.universeStartDate.toISOString(),
+      endDate: this.universeEndDate.toISOString(),
+    };
+
+    const venue = (this.universeVenue ?? '').trim();
+    const assetClass = (this.universeAssetClass ?? '').trim();
+    if (venue) {
+      request.venue = venue;
+    }
+    if (assetClass) {
+      request.assetClass = assetClass;
+    }
+
+    this.showUniverseRefreshButton = false;
+    this.universeImporting = true;
+    this.universeService
+      .importUniverse(request)
+      .pipe(finalize(() => (this.universeImporting = false)))
+      .subscribe({
+        next: () => {
+          this.snackBar.open(`Import univers ${this.selectedUniverseCode} lancé (async)`, 'OK', { duration: 4000 });
+          this.showUniverseRefreshButton = true;
+        },
+        error: err => {
+          console.error('Universe import failed', err);
+          this.snackBar.open("Erreur lors de l'import univers", 'Fermer', { duration: 5000 });
+        },
+      });
+  }
+
+  onRefreshAfterUniverse(): void {
+    this.refresh();
+    this.showUniverseRefreshButton = false;
   }
 
   ngAfterViewInit(): void {

--- a/src/app/services/universe.service.ts
+++ b/src/app/services/universe.service.ts
@@ -1,0 +1,37 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../environments/environment';
+
+export interface UniverseCatalog {
+  code: string;
+  name: string;
+  type: 'CRYPTO' | 'EQUITY' | string;
+  provider: string;
+  approxSize?: number;
+}
+
+export interface UniverseImportRequest {
+  code: string;
+  broker: string;
+  timeframe: string;
+  startDate: string; // ISO
+  endDate: string; // ISO
+  venue?: string;
+  assetClass?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UniverseService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = environment.apiUrl;
+
+  getCatalog(): Observable<UniverseCatalog[]> {
+    return this.http.get<UniverseCatalog[]>(`${this.apiUrl}/api/universes/catalog`);
+  }
+
+  importUniverse(req: UniverseImportRequest): Observable<unknown> {
+    return this.http.post(`${this.apiUrl}/api/universes/import`, req);
+  }
+}


### PR DESCRIPTION
## Summary
- add a UniverseService to fetch the catalog and trigger import jobs for universes
- extend the data availability page with a mode toggle and universe import workflow
- style the new universe form and expose a refresh option after launching an import

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915db24c7d08323b3de93f60e93aa1f)