### PR TITLE
Add universe search filter

### DIFF
--- a/src/app/pages/data-availability/data-availability.page.html
+++ b/src/app/pages/data-availability/data-availability.page.html
@@ -379,10 +379,18 @@
 
 <mat-card class="universe-card" aria-label="Formulaire d'import d'univers" *ngIf="mode === 'universe'">
   <div class="universe-form">
+    <input
+      type="text"
+      placeholder="Rechercher un univers..."
+      [(ngModel)]="universeSearchTerm"
+      (ngModelChange)="onUniverseSearchChange($event)"
+      class="universe-search-input"
+    />
+
     <mat-form-field appearance="outline">
       <mat-label>Univers</mat-label>
       <mat-select [(ngModel)]="selectedUniverseCode" name="universeCode">
-        <mat-option *ngFor="let u of universes" [value]="u.code">
+        <mat-option *ngFor="let u of filteredUniverses" [value]="u.code">
           {{ u.name }} ({{ u.type }} · {{ u.approxSize || '?' }} actifs)
         </mat-option>
       </mat-select>

--- a/src/app/pages/data-availability/data-availability.page.html
+++ b/src/app/pages/data-availability/data-availability.page.html
@@ -379,13 +379,10 @@
 
 <mat-card class="universe-card" aria-label="Formulaire d'import d'univers" *ngIf="mode === 'universe'">
   <div class="universe-form">
-    <input
-      type="text"
-      placeholder="Rechercher un univers..."
-      [(ngModel)]="universeSearchTerm"
-      (ngModelChange)="onUniverseSearchChange($event)"
-      class="universe-search-input"
-    />
+    <mat-form-field appearance="outline">
+      <mat-label>Rechercher un univers...</mat-label>
+      <input matInput [(ngModel)]="universeAssetClass" (ngModelChange)="onUniverseSearchChange($event)" placeholder="EQUITY, CRYPTO..." />
+    </mat-form-field>
 
     <mat-form-field appearance="outline">
       <mat-label>Univers</mat-label>

--- a/src/app/pages/data-availability/data-availability.page.ts
+++ b/src/app/pages/data-availability/data-availability.page.ts
@@ -163,6 +163,8 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
 
   mode: 'instrument' | 'universe' = 'instrument';
   universes: UniverseCatalog[] = [];
+  filteredUniverses: UniverseCatalog[] = [];
+  universeSearchTerm = '';
   selectedUniverseCode?: string;
   universeBroker = 'IBKR';
   universeTimeframe = '1d';
@@ -196,9 +198,14 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
       .getCatalog()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: universes => (this.universes = Array.isArray(universes) ? universes : []),
+        next: universes => {
+          this.universes = Array.isArray(universes) ? universes : [];
+          this.filteredUniverses = [...this.universes];
+        },
         error: err => {
           console.error('Failed to load universe catalog', err);
+          this.universes = [];
+          this.filteredUniverses = [];
           this.snackBar.open('Impossible de charger les univers disponibles, réessaie plus tard', 'Fermer', {
             duration: 5000,
           });
@@ -256,6 +263,21 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
     };
 
     this.refresh();
+  }
+
+  onUniverseSearchChange(term: string): void {
+    this.universeSearchTerm = term;
+    const t = term.trim().toLowerCase();
+    if (!t) {
+      this.filteredUniverses = [...this.universes];
+      return;
+    }
+    this.filteredUniverses = this.universes.filter(u =>
+      (u.code && u.code.toLowerCase().includes(t)) ||
+      (u.name && u.name.toLowerCase().includes(t)) ||
+      (u.type && u.type.toLowerCase().includes(t)) ||
+      (u.provider && u.provider.toLowerCase().includes(t))
+    );
   }
 
   onModeChange(event: MatButtonToggleChange): void {


### PR DESCRIPTION
## Summary
- add universe search state and filtered list to the data availability page
- initialize filtered universes after loading catalog and reset on errors
- add a search input to filter universes by code, name, type, or provider and use the filtered list in the selector

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929b0e31368832399b2300068bded93)