### PR TITLE
Fix universe search and asset class options

### DIFF
--- a/src/app/pages/data-availability/data-availability.page.html
+++ b/src/app/pages/data-availability/data-availability.page.html
@@ -381,7 +381,12 @@
   <div class="universe-form">
     <mat-form-field appearance="outline">
       <mat-label>Rechercher un univers...</mat-label>
-      <input matInput [(ngModel)]="universeAssetClass" (ngModelChange)="onUniverseSearchChange($event)" placeholder="EQUITY, CRYPTO..." />
+      <input
+        matInput
+        [(ngModel)]="universeSearchTerm"
+        (ngModelChange)="onUniverseSearchChange($event)"
+        placeholder="EQUITY, CRYPTO..."
+      />
     </mat-form-field>
 
     <mat-form-field appearance="outline">
@@ -419,7 +424,10 @@
 
     <mat-form-field appearance="outline">
       <mat-label>Asset class (optionnel)</mat-label>
-      <input matInput [(ngModel)]="universeAssetClass" name="universeAssetClass" placeholder="EQUITY, CRYPTO..." />
+      <mat-select [(ngModel)]="universeAssetClass" name="universeAssetClass">
+        <mat-option value="">—</mat-option>
+        <mat-option *ngFor="let asset of assetClassOptions" [value]="asset">{{ asset }}</mat-option>
+      </mat-select>
     </mat-form-field>
 
     <mat-form-field appearance="outline">

--- a/src/app/pages/data-availability/data-availability.page.ts
+++ b/src/app/pages/data-availability/data-availability.page.ts
@@ -156,6 +156,7 @@ export class DataAvailabilityPageComponent implements OnInit, AfterViewInit {
   readonly brokers = ['Binance', 'MEXC', 'IBKR', 'Databento CSV', 'CSV TradingView', 'Autre'];
   readonly marketTypes = ['FX', 'Crypto', 'Equity', 'ETF', 'Futures'];
   readonly universeBrokers = ['IBKR', 'BINANCE', 'MEXC', 'BYBIT', 'KUCOIN'];
+  readonly assetClassOptions = ['STOCK', 'FOREX', 'FUTURE', 'OPTION', 'INDEX', 'CFD'];
 
   symbols: SymbolRef[] = [];
   filteredSymbols$!: Observable<SymbolRef[]>;


### PR DESCRIPTION
## Summary
- separate the universe search input from the asset class selection so filtering is not overwritten
- restrict universe asset class selection to predefined choices

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942df0fa45883239695967bb4fec7ce)