### PR TITLE
Add dataset builder helper for statistic charts

### DIFF
--- a/src/app/components/statistic-data/statistic-data.component.spec.ts
+++ b/src/app/components/statistic-data/statistic-data.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { StatisticDataComponent } from './statistic-data.component';
+import { buildChartDatasets, StatisticDataComponent } from './statistic-data.component';
 
 describe('StatisticDataComponent', () => {
   let component: StatisticDataComponent;
@@ -19,5 +19,38 @@ describe('StatisticDataComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('buildChartDatasets maps labels and timeframes to datasets', () => {
+    const statistics = {
+      '1h': { bullish: 12, bearish: 4 },
+      '4h': { bullish: 8, bearish: 6 }
+    };
+    const statisticFields = ['bullish', 'bearish'];
+    const selectedTimeframes = ['1h', '4h'];
+
+    const result = buildChartDatasets(statistics, statisticFields, selectedTimeframes);
+
+    expect(result.labels).toEqual(['bullish', 'bearish']);
+    expect(result.datasets).toHaveSize(2);
+    expect(result.datasets[0].label).toBe('1h');
+    expect(result.datasets[0].data).toEqual([12, 4]);
+    expect(result.datasets[1].label).toBe('4h');
+    expect(result.datasets[1].data).toEqual([8, 6]);
+  });
+
+  it('buildChartDatasets fills missing or null values with zeros', () => {
+    const statistics = {
+      '1h': { bullish: 5, bearish: null },
+      '4h': { bullish: 2 }
+    };
+    const statisticFields = ['bullish', 'bearish', 'neutral'];
+    const selectedTimeframes = ['1h', '4h'];
+
+    const result = buildChartDatasets(statistics, statisticFields, selectedTimeframes);
+
+    expect(result.datasets).toHaveSize(2);
+    expect(result.datasets[0].data).toEqual([5, 0, 0]);
+    expect(result.datasets[1].data).toEqual([2, 0, 0]);
   });
 });

--- a/src/app/components/statistic-data/statistic-data.component.ts
+++ b/src/app/components/statistic-data/statistic-data.component.ts
@@ -5,6 +5,30 @@ import {FormsModule} from '@angular/forms';
 import { Chart } from 'chart.js';
 import { NgChartsModule } from 'ng2-charts';
 
+export type ChartDatasetPayload = {
+  labels: string[];
+  datasets: Array<{
+    label: string;
+    data: number[];
+    backgroundColor: string;
+  }>;
+};
+
+export function buildChartDatasets(
+  statistics: Record<string, Record<string, number | null | undefined>> | undefined,
+  statisticFields: string[],
+  selectedTimeframes: string[]
+): ChartDatasetPayload {
+  const labels = statisticFields;
+  const datasets = selectedTimeframes.map(tf => ({
+    label: tf,
+    data: labels.map(stat => statistics?.[tf]?.[stat] ?? 0),
+    backgroundColor: 'rgba(75,192,192,0.6)'
+  }));
+
+  return { labels, datasets };
+}
+
 @Component({
   selector: 'app-statistics',
   templateUrl: './statistic-data.component.html',
@@ -221,12 +245,11 @@ export class StatisticDataComponent {
       this.chart.destroy();
     }
 
-    const labels = this.statisticFields;
-    const datasets = this.selectedTimeframes.map(tf => ({
-      label: tf,
-      data: labels.map(stat => this.statistics[tf]?.[stat] ?? 0),
-      backgroundColor: 'rgba(75,192,192,0.6)'
-    }));
+    const { labels, datasets } = buildChartDatasets(
+      this.statistics,
+      this.statisticFields,
+      this.selectedTimeframes
+    );
 
     this.chart = new Chart(ctx, {
       type: 'bar',


### PR DESCRIPTION
### Motivation
- Isolate and reuse the logic that converts HTTP statistic payloads into Chart.js datasets to make it testable and clearer.
- Ensure chart rendering uses a single source of truth for dataset construction to avoid duplication and subtle bugs.
- Add unit tests that validate dataset mapping and robustness against missing or null values.

### Description
- Export a new `buildChartDatasets` function and `ChartDatasetPayload` type in `src/app/components/statistic-data/statistic-data.component.ts` to build labels and datasets from `statistics`, `statisticFields`, and `selectedTimeframes`.
- Replace inline dataset construction in `renderChart()` with a call to `buildChartDatasets` so chart creation uses the helper.
- Add unit tests in `src/app/components/statistic-data/statistic-data.component.spec.ts` that verify mapping of labels/timeframes and filling of missing or `null` values with zeros.

### Testing
- Added unit tests in `statistic-data.component.spec.ts` that assert dataset counts, label/timeframe mapping, and missing/null handling using `buildChartDatasets`.
- No automated test runner was executed as part of this change, so test execution status is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949dd77a86083238d55b77bd36509be)