### PR TITLE
Add candlestick utilities and unit tests for OHLC mapping, annotations and dataset alignment

### DIFF
--- a/src/app/components/candlestick-chart.utils.ts
+++ b/src/app/components/candlestick-chart.utils.ts
@@ -1,0 +1,65 @@
+export interface CandleLike {
+  date: string | number | Date;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+export interface OhlcPoint {
+  x: number;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+}
+
+export interface TradeLike {
+  stopLoss: number;
+  takeProfit: number;
+  result: string;
+}
+
+const isValidTimestamp = (value: string | number | Date): value is string | number => {
+  const timestamp = new Date(value).getTime();
+  return !Number.isNaN(timestamp);
+};
+
+export const mapCandlesToOhlc = (candles: CandleLike[] = []): OhlcPoint[] => {
+  return candles
+    .filter((candle) => isValidTimestamp(candle.date))
+    .map((candle) => ({
+      x: new Date(candle.date).getTime(),
+      o: candle.open,
+      h: candle.high,
+      l: candle.low,
+      c: candle.close
+    }));
+};
+
+export const alignComparedOhlc = (primary: OhlcPoint[], compared: OhlcPoint[]): OhlcPoint[] => {
+  const primaryTimestamps = new Set(primary.map((point) => point.x));
+  return compared.filter((point) => primaryTimestamps.has(point.x));
+};
+
+export const buildOhlcDataset = (data: OhlcPoint[], label: string) => ({
+  label,
+  data
+});
+
+export const buildTradeAnnotation = (trade: TradeLike, entryTime: number, exitTime: number) => ({
+  tradeBox: {
+    type: 'box' as const,
+    xMin: entryTime,
+    xMax: exitTime,
+    yMin: trade.stopLoss,
+    yMax: trade.takeProfit,
+    backgroundColor: trade.result === 'win' ? 'rgba(0,255,0,0.2)' : 'rgba(255,0,0,0.2)',
+    borderColor: trade.result === 'win' ? 'green' : 'red',
+    borderWidth: 2,
+    label: {
+      content: 'Trade',
+      position: 'start' as const
+    }
+  }
+});

--- a/src/app/components/historical-data/historical-data.component.ts
+++ b/src/app/components/historical-data/historical-data.component.ts
@@ -11,6 +11,7 @@ import {FormsModule} from '@angular/forms';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import { AnnotationOptions, LineAnnotationOptions, LabelPosition } from 'chartjs-plugin-annotation';
 import { format } from 'date-fns';
+import { mapCandlesToOhlc } from '../candlestick-chart.utils';
 
 @Component({
   selector: 'app-historical-data',
@@ -166,13 +167,7 @@ export class HistoricalDataComponent implements OnInit, AfterViewInit {
         datasets: [
           {
             label: (this.selectedSymbol || '—') + ' - ' + this.selectedTimeframe,
-            data: this.candles.map(c => ({
-              x: new Date(c.date).getTime(),
-              o: c.open,
-              h: c.high,
-              l: c.low,
-              c: c.close
-            })),
+            data: mapCandlesToOhlc(this.candles),
             borderColor: 'black',
             backgroundColor: 'rgba(0, 128, 0, 0.5)',
             barThickness: 1,
@@ -251,5 +246,4 @@ export class HistoricalDataComponent implements OnInit, AfterViewInit {
     });
   }
 }
-
 

--- a/src/app/components/trade-candlestick-chart/trade-candlestick-chart.component.spec.ts
+++ b/src/app/components/trade-candlestick-chart/trade-candlestick-chart.component.spec.ts
@@ -1,6 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TradeCandlestickChartComponent } from './trade-candlestick-chart.component';
+import {
+  alignComparedOhlc,
+  buildOhlcDataset,
+  buildTradeAnnotation,
+  mapCandlesToOhlc
+} from '../candlestick-chart.utils';
 
 describe('TradeCandlestickChartComponent', () => {
   let component: TradeCandlestickChartComponent;
@@ -19,5 +25,54 @@ describe('TradeCandlestickChartComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('maps candles to OHLC points', () => {
+    const candles = [
+      { date: '2024-01-01T00:00:00Z', open: 1, high: 2, low: 0.5, close: 1.5 },
+      { date: 'invalid-date', open: 10, high: 20, low: 5, close: 15 }
+    ];
+
+    const result = mapCandlesToOhlc(candles);
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual({
+      x: new Date('2024-01-01T00:00:00Z').getTime(),
+      o: 1,
+      h: 2,
+      l: 0.5,
+      c: 1.5
+    });
+  });
+
+  it('builds trade annotations with entry and exit bounds', () => {
+    const trade = { stopLoss: 1.1, takeProfit: 1.4, result: 'win' };
+    const entryTime = 1700000000000;
+    const exitTime = 1700003600000;
+
+    const annotations = buildTradeAnnotation(trade, entryTime, exitTime);
+
+    expect(annotations.tradeBox.xMin).toBe(entryTime);
+    expect(annotations.tradeBox.xMax).toBe(exitTime);
+    expect(annotations.tradeBox.yMin).toBe(trade.stopLoss);
+    expect(annotations.tradeBox.yMax).toBe(trade.takeProfit);
+  });
+
+  it('aligns compared dataset and keeps it distinct', () => {
+    const primary = mapCandlesToOhlc([
+      { date: '2024-01-01T00:00:00Z', open: 1, high: 2, low: 0.5, close: 1.5 },
+      { date: '2024-01-01T01:00:00Z', open: 1.1, high: 2.1, low: 0.6, close: 1.6 }
+    ]);
+    const compared = mapCandlesToOhlc([
+      { date: '2024-01-01T00:00:00Z', open: 10, high: 20, low: 5, close: 15 },
+      { date: '2024-01-01T02:00:00Z', open: 11, high: 21, low: 6, close: 16 }
+    ]);
+
+    const aligned = alignComparedOhlc(primary, compared);
+    const dataset = buildOhlcDataset(aligned, 'COMPARED');
+
+    expect(aligned.map((point) => point.x)).toEqual([primary[0].x]);
+    expect(dataset.label).toBe('COMPARED');
+    expect(dataset.data).toBe(aligned);
   });
 });

--- a/src/app/components/trade-candlestick-chart/trade-candlestick-chart.component.ts
+++ b/src/app/components/trade-candlestick-chart/trade-candlestick-chart.component.ts
@@ -8,6 +8,12 @@ import {
   CandlestickController,
   CandlestickElement
 } from 'chartjs-chart-financial';
+import {
+  alignComparedOhlc,
+  buildOhlcDataset,
+  buildTradeAnnotation,
+  mapCandlesToOhlc
+} from '../candlestick-chart.utils';
 
 @Component({
   selector: 'app-trade-candlestick-chart',
@@ -41,25 +47,9 @@ export class TradeCandlestickChartComponent implements OnChanges {
       const { candles, trade, comparedCandles } = response as any;
 
       // 🛡️ Validation des données
-      const data = candles
-        .filter((c: any) => !isNaN(new Date(c.date).getTime()))
-        .map((c: any) => ({
-          x: new Date(c.date).getTime(),
-          o: c.open,
-          h: c.high,
-          l: c.low,
-          c: c.close
-        }));
-
-      const comparedData = (comparedCandles || [])
-        .filter((c: any) => !isNaN(new Date(c.date).getTime()))
-        .map((c: any) => ({
-          x: new Date(c.date).getTime(),
-          o: c.open,
-          h: c.high,
-          l: c.low,
-          c: c.close
-        }));
+      const data = mapCandlesToOhlc(candles);
+      const comparedData = mapCandlesToOhlc(comparedCandles || []);
+      const alignedComparedData = alignComparedOhlc(data, comparedData);
 
       console.log('[Candles]', candles);
       console.log('[Trade]', trade);
@@ -78,15 +68,15 @@ export class TradeCandlestickChartComponent implements OnChanges {
       }
 
       setTimeout(() => {
-        this.renderChart(data, trade, 'tradeCandlestickChart', true);
-        if (comparedData.length) {
-          this.renderChart(comparedData, trade, 'comparedCandlestickChart', false);
+        this.renderChart(data, trade, 'tradeCandlestickChart', true, `Trade #${this.tradeId}`);
+        if (alignedComparedData.length) {
+          this.renderChart(alignedComparedData, trade, 'comparedCandlestickChart', false, this.comparedSymbol);
         }
       }, 0);
     });
   }
 
-  renderChart(data: any[], trade: any, canvasId: string, annotate: boolean): void {
+  renderChart(data: any[], trade: any, canvasId: string, annotate: boolean, label: string): void {
     const canvas = document.getElementById(canvasId) as HTMLCanvasElement;
     const ctx = canvas?.getContext('2d');
     if (!data?.length || !trade || !canvas || !ctx) {
@@ -114,10 +104,7 @@ export class TradeCandlestickChartComponent implements OnChanges {
     const newChart = new Chart(ctx, {
       type: 'candlestick',
       data: {
-        datasets: [{
-          label: canvasId === 'tradeCandlestickChart' ? `Trade #${this.tradeId}` : this.comparedSymbol,
-          data,
-        }]
+        datasets: [buildOhlcDataset(data, label)]
       },
       options: {
         responsive: true,
@@ -145,23 +132,7 @@ export class TradeCandlestickChartComponent implements OnChanges {
         },
         plugins: {
           annotation: annotate ? {
-            annotations: {
-              tradeBox: {
-                type: 'box',
-                xMin: entryTime,
-                xMax: exitTime,
-                yMin: trade.stopLoss,
-                yMax: trade.takeProfit,
-                backgroundColor: trade.result === 'win' ? 'rgba(0,255,0,0.2)' : 'rgba(255,0,0,0.2)',
-                borderColor: trade.result === 'win' ? 'green' : 'red',
-                borderWidth: 2,
-                label: {
-                  content: 'Trade',
-                  //enabled: true,
-                  position: 'start'
-                }
-              }
-            }
+            annotations: buildTradeAnnotation(trade, entryTime, exitTime)
           } : undefined,
           zoom: {
             pan: {


### PR DESCRIPTION
### Motivation
- Extract chart data transformation and annotation logic into testable utilities to improve maintainability and unit test coverage.
- Ensure OHLC mapping is robust against invalid timestamps and that compared series are aligned to the primary series.
- Make trade annotation construction reusable and consistent across candlestick components.

### Description
- Add `src/app/components/candlestick-chart.utils.ts` with `mapCandlesToOhlc`, `alignComparedOhlc`, `buildOhlcDataset`, and `buildTradeAnnotation` utilities.
- Refactor `TradeCandlestickChartComponent` to use the utilities and align compared datasets before rendering, and update `renderChart` to accept a `label` parameter.
- Refactor `HistoricalDataComponent` to use `mapCandlesToOhlc` for dataset construction.
- Add unit tests in `src/app/components/trade-candlestick-chart/trade-candlestick-chart.component.spec.ts` that exercise OHLC mapping, trade annotation creation, and compared dataset alignment.

### Testing
- Added unit tests covering `mapCandlesToOhlc` (OHLC mapping), `buildTradeAnnotation` (entry/exit annotation bounds), and `alignComparedOhlc` (compared dataset alignment). 
- Tests are included in `trade-candlestick-chart.component.spec.ts` and assert expected shapes and values for datasets and annotations.
- No automated test suite was executed as part of this change (tests were added but not run in CI in this rollout).
- Manual runtime or CI test execution is recommended to validate integrations with Chart.js plugins and DOM-dependent chart rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949dd78e8a4832391323ff438fd9335)