### PR TITLE
Add unit tests for StrategyCalculationComponent and fix result handling on errors

### DIFF
--- a/src/app/components/strategy-calculation/strategy-calculation.component.spec.ts
+++ b/src/app/components/strategy-calculation/strategy-calculation.component.spec.ts
@@ -1,14 +1,26 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { By } from '@angular/platform-browser';
+import { of, throwError } from 'rxjs';
 
 import { StrategyCalculationComponent } from './strategy-calculation.component';
+import { TradingDataService } from '../../services/trading-data.service';
 
 describe('StrategyCalculationComponent', () => {
   let component: StrategyCalculationComponent;
   let fixture: ComponentFixture<StrategyCalculationComponent>;
+  let tradingServiceSpy: jasmine.SpyObj<TradingDataService>;
 
   beforeEach(async () => {
+    tradingServiceSpy = jasmine.createSpyObj('TradingDataService', [
+      'listStrategies',
+      'getCalculationStrategy'
+    ]);
+    tradingServiceSpy.listStrategies.and.returnValue(of(['Strat-A', 'Strat-B']));
+
     await TestBed.configureTestingModule({
-      imports: [StrategyCalculationComponent]
+      imports: [HttpClientTestingModule, StrategyCalculationComponent],
+      providers: [{ provide: TradingDataService, useValue: tradingServiceSpy }]
     })
     .compileComponents();
 
@@ -19,5 +31,64 @@ describe('StrategyCalculationComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should initialize with empty form state', () => {
+    expect(component.selectedStrategy).toBe('');
+    expect(component.selectedSymbol).toBe('');
+    expect(component.selectedComparedSymbol).toBe('');
+    expect(component.selectedTimeframe).toBe('');
+    expect(component.startDate).toBe('');
+    expect(component.endDate).toBe('');
+    expect(component.result).toBeNull();
+  });
+
+  it('should submit and call the service with expected payload', () => {
+    const response = { total: 42, trades: 5 };
+    tradingServiceSpy.getCalculationStrategy.and.returnValue(of(response));
+
+    component.selectedStrategy = 'Strat-A';
+    component.selectedSymbol = 'ES';
+    component.selectedComparedSymbol = 'NQ';
+    component.selectedTimeframe = '1h';
+    component.startDate = '2024-01-01T10:00';
+    component.endDate = '2024-01-02T10:00';
+
+    component.calculateStrategy();
+
+    expect(tradingServiceSpy.getCalculationStrategy).toHaveBeenCalledWith(
+      'Strat-A',
+      'ES',
+      'NQ',
+      '1h',
+      '2024-01-01T10:00',
+      '2024-01-02T10:00'
+    );
+    expect(component.result).toEqual(response);
+
+    fixture.detectChanges();
+    const pre = fixture.debugElement.query(By.css('pre')).nativeElement as HTMLElement;
+    expect(pre.textContent).toContain('"total": 42');
+    expect(pre.textContent).toContain('"trades": 5');
+  });
+
+  it('should handle service errors when calculation fails', () => {
+    const error = new Error('Service failure');
+    tradingServiceSpy.getCalculationStrategy.and.returnValue(throwError(() => error));
+    const consoleSpy = spyOn(console, 'error');
+
+    component.selectedStrategy = 'Strat-A';
+    component.selectedSymbol = 'ES';
+    component.selectedComparedSymbol = 'NQ';
+    component.selectedTimeframe = '1h';
+    component.startDate = '2024-01-01T10:00';
+    component.endDate = '2024-01-02T10:00';
+
+    component.calculateStrategy();
+
+    expect(consoleSpy).toHaveBeenCalledWith('Erreur lors du calcul de stratégie :', error);
+    expect(component.result).toBeNull();
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('pre'))).toBeNull();
   });
 });

--- a/src/app/components/strategy-calculation/strategy-calculation.component.ts
+++ b/src/app/components/strategy-calculation/strategy-calculation.component.ts
@@ -48,7 +48,7 @@ export class StrategyCalculationComponent implements OnInit {
       alert('Tous les champs sont requis pour lancer le calcul !');
       return;
     }
-    this.result = this.tradingService
+    this.tradingService
       .getCalculationStrategy(
         this.selectedStrategy,
         this.selectedSymbol,
@@ -58,13 +58,14 @@ export class StrategyCalculationComponent implements OnInit {
         this.endDate
       )
       .subscribe({
-      next: (response) => {
-        console.log('Résultat de la stratégie', response);
-        this.result = response;
-      },
-      error: (error) => {
-        console.error('Erreur lors du calcul de stratégie :', error);
-      }
-    });
+        next: (response) => {
+          console.log('Résultat de la stratégie', response);
+          this.result = response;
+        },
+        error: (error) => {
+          console.error('Erreur lors du calcul de stratégie :', error);
+          this.result = null;
+        }
+      });
   }
 }


### PR DESCRIPTION
### Motivation
- Add unit tests to validate the strategy calculation form, service interaction, DOM binding and error paths.
- Prevent storing the subscription object in the component `result` property and ensure `result` is only populated on successful responses.
- Improve reliability of `calculateStrategy` by resetting `result` when the service returns an error.

### Description
- Stop assigning the subscription to `result` and instead set `result` on success and reset it to `null` on error in `calculateStrategy`.
- Add `src/app/components/strategy-calculation/strategy-calculation.component.spec.ts` which mocks `TradingDataService` using a `jasmine.SpyObj` and `of`/`throwError` for responses.
- Tests assert the initial empty form state, that calling `calculateStrategy` invokes `getCalculationStrategy` with the expected arguments, and that the returned JSON is bound into the DOM `pre` element.
- Add `HttpClientTestingModule` and use `By` for DOM assertions in the test file.

### Testing
- No automated test runner was executed during this rollout, so the new unit tests were added but not run.
- The added tests use `jasmine.SpyObj` to mock `listStrategies` and `getCalculationStrategy` and exercise success and error flows.
- The changes compile locally as part of the edit and commit, but `ng test` was not executed in this PR generation step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949dd79b0748323b3d9548d942eb5e0)