### PR TITLE
Add SignalsStore unit tests with localStorage mocks

### DIFF
--- a/src/app/labs/signals/state/signals.store.spec.ts
+++ b/src/app/labs/signals/state/signals.store.spec.ts
@@ -2,7 +2,14 @@ import { SignalsStore } from './signals.store';
 
 describe('SignalsStore', () => {
   let store: SignalsStore;
-  beforeEach(() => { store = new SignalsStore(); });
+  let getItemSpy: jasmine.Spy;
+  let setItemSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    getItemSpy = spyOn(localStorage, 'getItem').and.returnValue(null);
+    setItemSpy = spyOn(localStorage, 'setItem');
+    store = new SignalsStore();
+  });
 
   it('increments/decrements/resets count', () => {
     expect(store.count()).toBe(0);
@@ -29,5 +36,32 @@ describe('SignalsStore', () => {
 
     store.clearCompleted();
     expect(store.todos().length).toBe(0);
+  });
+
+  it('filters todos by status', () => {
+    store.addTodo('A');
+    store.addTodo('B');
+    const [firstId] = store.todos().map(t => t.id);
+
+    store.toggleTodo(firstId);
+
+    store.filter.set('active');
+    expect(store.filteredTodos().every(t => !t.completed)).toBeTrue();
+    expect(store.filteredTodos().length).toBe(1);
+
+    store.filter.set('completed');
+    expect(store.filteredTodos().every(t => t.completed)).toBeTrue();
+    expect(store.filteredTodos().length).toBe(1);
+
+    store.filter.set('all');
+    expect(store.filteredTodos().length).toBe(2);
+  });
+
+  it('persists count changes to localStorage', () => {
+    const key = 'signals-demo:count';
+    expect(getItemSpy).toHaveBeenCalledWith(key);
+
+    store.inc();
+    expect(setItemSpy).toHaveBeenCalledWith(key, '1');
   });
 });


### PR DESCRIPTION
### Motivation

- Increase unit test coverage for the `SignalsStore` and verify its behavior around counters, todos, filtering and persistence.
- Ensure the `persist` effect reads and writes the `signals-demo:count` key in `localStorage` as expected.

### Description

- Added `localStorage` spies in `beforeEach` using `spyOn(localStorage, 'getItem')` and `spyOn(localStorage, 'setItem')` to isolate persistence behavior.
- Expanded `src/app/labs/signals/state/signals.store.spec.ts` with tests for increment/decrement/reset of `count` and existing todo management flows (`addTodo`, `toggleTodo`, `removeTodo`, `clearCompleted`).
- Added tests that assert `filteredTodos` for `active`, `completed`, and `all` filters produce the expected lists.
- Added a test that asserts the store reads the stored count on initialization and writes the count to `localStorage` when `count` changes.

### Testing

- Unit tests were added to `src/app/labs/signals/state/signals.store.spec.ts` but no automated test run was executed as part of this change.
- No CI or `ng test` results are included with this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949dd7a81ac8323868fff274e106f31)