### PR TITLE
Add LiveDataComponent start/stop UI unit tests

### DIFF
--- a/src/app/components/live-data/live-data.component.spec.ts
+++ b/src/app/components/live-data/live-data.component.spec.ts
@@ -1,38 +1,128 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
 
 import { LiveDataComponent } from './live-data.component';
 import { MarketDataService } from '../../services/market-data.service';
-import { StartBarsResponse, TradeView } from '../../models/trading.models';
-
-class MarketDataServiceStub {
-  connectWait = jasmine.createSpy('connectWait').and.returnValue(of({ connected: true }));
-  setMarketDataType = jasmine.createSpy('setMarketDataType').and.returnValue(of({ ok: true, marketDataType: 3 }));
-  startLiveBars = jasmine.createSpy('startLiveBars').and.callFake(() =>
-    of({ reqId: 1, pair: 'EURUSD', duration: '1 D', barSize: '1 min', what: 'MIDPOINT', rth: 0, formatDate: 2 } satisfies StartBarsResponse)
-  );
-  getLiveBars = jasmine.createSpy('getLiveBars').and.returnValue(of([]));
-  getLastLiveBar = jasmine.createSpy('getLastLiveBar').and.returnValue(of(null));
-  stopLiveBars = jasmine.createSpy('stopLiveBars').and.returnValue(of({ reqId: 1, stopped: true }));
-  listTrades = jasmine.createSpy('listTrades').and.returnValue(of([] as TradeView[]));
-}
+import { HistBar, StartBarsResponse, TradeView } from '../../models/trading.models';
 
 describe('LiveDataComponent', () => {
   let component: LiveDataComponent;
   let fixture: ComponentFixture<LiveDataComponent>;
+  let marketDataService: jasmine.SpyObj<MarketDataService>;
+  let chartStubPrimary: { data: { datasets: Array<{ data: unknown[] }> }; update: jasmine.Spy };
+  let chartStubSecondary: { data: { datasets: Array<{ data: unknown[] }> }; update: jasmine.Spy };
 
   beforeEach(async () => {
+    marketDataService = jasmine.createSpyObj('MarketDataService', [
+      'connectWait',
+      'setMarketDataType',
+      'startLiveBars',
+      'getLiveBars',
+      'getLastLiveBar',
+      'stopLiveBars',
+      'listTrades',
+      'getPortfolioSnapshots'
+    ]);
+
+    marketDataService.connectWait.and.returnValue(of({ connected: true }));
+    marketDataService.setMarketDataType.and.returnValue(of({ ok: true, marketDataType: 3 }));
+    marketDataService.startLiveBars.and.returnValue(
+      of({
+        reqId: 1,
+        pair: 'EURUSD',
+        duration: '1 D',
+        barSize: '1 min',
+        what: 'MIDPOINT',
+        rth: 0,
+        formatDate: 2
+      } satisfies StartBarsResponse)
+    );
+    marketDataService.getLiveBars.and.returnValue(of([]));
+    marketDataService.getLastLiveBar.and.returnValue(of(null));
+    marketDataService.stopLiveBars.and.returnValue(of({ reqId: 1, stopped: true }));
+    marketDataService.listTrades.and.returnValue(of([] as TradeView[]));
+    marketDataService.getPortfolioSnapshots.and.returnValue(of([]));
+
+    spyOn<any>(LiveDataComponent.prototype, 'initializeCharts').and.stub();
+
     await TestBed.configureTestingModule({
       imports: [LiveDataComponent],
-      providers: [{ provide: MarketDataService, useClass: MarketDataServiceStub }]
+      providers: [{ provide: MarketDataService, useValue: marketDataService }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(LiveDataComponent);
     component = fixture.componentInstance;
+    chartStubPrimary = { data: { datasets: [{ data: [] }] }, update: jasmine.createSpy('update') };
+    chartStubSecondary = { data: { datasets: [{ data: [] }] }, update: jasmine.createSpy('update') };
+    (component as any).charts = [chartStubPrimary, chartStubSecondary];
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should start live bars from the UI and update the dataset', fakeAsync(() => {
+    const connectButton = getButtonByLabel('Connect & Wait');
+    connectButton.click();
+    fixture.detectChanges();
+
+    const bars: HistBar[] = [
+      { tsMillis: 1000, open: 1, high: 2, low: 0.5, close: 1.5 },
+      { tsMillis: 2000, open: 1.5, high: 2.5, low: 1, close: 2 }
+    ] as HistBar[];
+    marketDataService.getLiveBars.and.returnValue(of(bars));
+
+    const startButton = getButtonByLabel('Start Live Bars');
+    startButton.click();
+    tick();
+    fixture.detectChanges();
+
+    const panel = component.panels[0];
+    expect(panel.reqId).toBe(1);
+    expect(panel.bars.length).toBe(2);
+    expect(chartStubPrimary.data.datasets[0].data.length).toBe(2);
+    expect(chartStubPrimary.update).toHaveBeenCalled();
+  }));
+
+  it('should stop live bars and prevent further updates', fakeAsync(() => {
+    const connectButton = getButtonByLabel('Connect & Wait');
+    connectButton.click();
+    fixture.detectChanges();
+
+    const bars: HistBar[] = [
+      { tsMillis: 1000, open: 1, high: 2, low: 0.5, close: 1.5 }
+    ] as HistBar[];
+    marketDataService.getLiveBars.and.returnValue(of(bars));
+
+    const startButton = getButtonByLabel('Start Live Bars');
+    startButton.click();
+    tick();
+    fixture.detectChanges();
+
+    const initialCalls = marketDataService.getLiveBars.calls.count();
+
+    const stopButton = getButtonByLabel('Stop Live Bars');
+    stopButton.click();
+    tick();
+    fixture.detectChanges();
+
+    tick(4000);
+    fixture.detectChanges();
+
+    const panel = component.panels[0];
+    expect(panel.reqId).toBeNull();
+    expect(panel.bars.length).toBe(0);
+    expect(marketDataService.getLiveBars.calls.count()).toBe(initialCalls);
+  }));
+
+  function getButtonByLabel(label: string): HTMLButtonElement {
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const match = buttons.find(button => button.nativeElement.textContent?.trim() === label);
+    if (!match) {
+      throw new Error(`Button with label "${label}" not found.`);
+    }
+    return match.nativeElement as HTMLButtonElement;
+  }
 });


### PR DESCRIPTION
### Motivation
- Add coverage for starting and stopping live bars in `LiveDataComponent` through the UI to ensure internal state and dataset updates behave correctly.
- Replace the simple stub approach with a spy-based `MarketDataService` so test scenarios can control `connectWait`, `startLiveBars`, `getLiveBars`, and `stopLiveBars` responses.
- Verify that stopping a stream halts polling and resets the panel state and datasets.

### Description
- Updated `src/app/components/live-data/live-data.component.spec.ts` to use a `jasmine.SpyObj<MarketDataService>` and provide stubbed returns for `connectWait`, `startLiveBars`, `getLiveBars`, `stopLiveBars`, `listTrades`, and `getPortfolioSnapshots`.
- Added UI-driven tests using `fakeAsync`/`tick` that simulate clicking `Connect & Wait`, `Start Live Bars`, and `Stop Live Bars` and assert `panel.reqId`, `panel.bars`, and chart dataset updates.
- Stubbed the component charts and spied on `initializeCharts` to avoid real `Chart.js` initialization during tests.
- Added a `getButtonByLabel` test helper that locates buttons by their visible text via `By.css`.

### Testing
- New automated unit tests were added in `src/app/components/live-data/live-data.component.spec.ts` to cover start and stop flows.
- The tests use `fakeAsync` and `tick` to simulate polling intervals and asynchronous behavior.
- Chart updates are asserted via chart stub spies to confirm `update` was called and datasets were populated.
- The new tests were added but were not executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3c74c6648323952c275e8b087f13)