### PR TITLE
Add router-based unit tests for strategy navigation and detail loading

### DIFF
--- a/src/app/components/screen-strategies/screen-strategies.component.spec.ts
+++ b/src/app/components/screen-strategies/screen-strategies.component.spec.ts
@@ -1,14 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 
+import { TradingDataService } from '../../services/trading-data.service';
 import { ScreenStrategiesComponent } from './screen-strategies.component';
 
 describe('ScreenStrategiesComponent', () => {
   let component: ScreenStrategiesComponent;
   let fixture: ComponentFixture<ScreenStrategiesComponent>;
+  let tradingDataServiceSpy: jasmine.SpyObj<TradingDataService>;
 
   beforeEach(async () => {
+    tradingDataServiceSpy = jasmine.createSpyObj('TradingDataService', ['getAllCalculatedStrategies']);
+    tradingDataServiceSpy.getAllCalculatedStrategies.and.returnValue(of([]));
+
     await TestBed.configureTestingModule({
-      imports: [ScreenStrategiesComponent]
+      imports: [ScreenStrategiesComponent, RouterTestingModule],
+      providers: [{ provide: TradingDataService, useValue: tradingDataServiceSpy }]
     })
     .compileComponents();
 
@@ -19,5 +28,28 @@ describe('ScreenStrategiesComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('navigates to strategy detail with route params when clicking go', () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = spyOn(router, 'navigate');
+
+    component.strategies = [
+      {
+        name: 'Breakout 1',
+        runId: 'run-123',
+        symbol: 'EUR/USD'
+      }
+    ];
+
+    fixture.detectChanges();
+
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(navigateSpy).toHaveBeenCalledWith(
+      ['/strategy-detail', 'Breakout 1', 'run-123', 'EUR/USD', 'none'],
+      { state: { strategy: component.strategies[0] } }
+    );
   });
 });

--- a/src/app/components/strategy-detail/strategy-detail.component.spec.ts
+++ b/src/app/components/strategy-detail/strategy-detail.component.spec.ts
@@ -1,14 +1,54 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 
+import { TradingDataService } from '../../services/trading-data.service';
 import { StrategyDetailComponent } from './strategy-detail.component';
 
 describe('StrategyDetailComponent', () => {
   let component: StrategyDetailComponent;
   let fixture: ComponentFixture<StrategyDetailComponent>;
+  let tradingDataServiceSpy: jasmine.SpyObj<TradingDataService>;
 
   beforeEach(async () => {
+    tradingDataServiceSpy = jasmine.createSpyObj('TradingDataService', [
+      'getAllCalculatedStrategies',
+      'getTradesByStrategyName'
+    ]);
+    tradingDataServiceSpy.getAllCalculatedStrategies.and.returnValue(of([
+      {
+        runId: 'run-123',
+        name: 'Breakout 1',
+        symbol: 'EUR/USD',
+        comparedSymbol: 'GBP/USD'
+      }
+    ]));
+    tradingDataServiceSpy.getTradesByStrategyName.and.returnValue(of([]));
+
     await TestBed.configureTestingModule({
-      imports: [StrategyDetailComponent]
+      imports: [StrategyDetailComponent, RouterTestingModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: (key: string) => {
+                  const params: Record<string, string> = {
+                    name: 'Breakout 1',
+                    runId: 'run-123',
+                    symbol: 'EUR/USD',
+                    comparedSymbol: 'GBP/USD'
+                  };
+                  return params[key] ?? null;
+                }
+              }
+            }
+          }
+        },
+        { provide: TradingDataService, useValue: tradingDataServiceSpy }
+      ]
     })
     .compileComponents();
 
@@ -19,5 +59,25 @@ describe('StrategyDetailComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('loads strategy data from route params', () => {
+    const router = TestBed.inject(Router);
+    spyOn(router, 'getCurrentNavigation').and.returnValue(null as never);
+
+    component.loadStrategy();
+
+    expect(tradingDataServiceSpy.getAllCalculatedStrategies).toHaveBeenCalled();
+    expect(tradingDataServiceSpy.getTradesByStrategyName).toHaveBeenCalledWith('Breakout 1', 'run-123');
+    expect(component.symbol).toBe('EUR/USD');
+    expect(component.comparedSymbol).toBe('GBP/USD');
+    expect(component.strategy).toEqual(
+      jasmine.objectContaining({
+        name: 'Breakout 1',
+        runId: 'run-123',
+        symbol: 'EUR/USD',
+        comparedSymbol: 'GBP/USD'
+      })
+    );
   });
 });


### PR DESCRIPTION
### Motivation

- Add coverage for navigation from the strategies list to the detail page and ensure route parameters are assembled correctly using `RouterTestingModule`.
- Verify that `StrategyDetailComponent` reads route params (`name`, `runId`, `symbol`, `comparedSymbol`) and loads data when navigation state is not present.
- Provide deterministic behavior in tests by stubbing `TradingDataService` to avoid calling real backends.

### Description

- Updated `src/app/components/screen-strategies/screen-strategies.component.spec.ts` to import `RouterTestingModule`, provide a `TradingDataService` spy, and add a test that clicks the list button and asserts `Router.navigate` is called with `['/strategy-detail', name, runId, symbol, 'none']` and the navigation `state` contains the strategy.
- Updated `src/app/components/strategy-detail/strategy-detail.component.spec.ts` to import `RouterTestingModule`, provide an `ActivatedRoute` stub returning route params, and add a `TradingDataService` spy that stubs `getAllCalculatedStrategies` and `getTradesByStrategyName` for deterministic assertions.
- New tests assert that `StrategyDetailComponent.loadStrategy()` calls the service methods and sets `symbol`, `comparedSymbol`, and `strategy` based on the provided route params.

### Testing

- Added unit tests (`*.spec.ts`) that exercise router navigation and route-param loading, implemented with `RouterTestingModule` and service spies.
- No automated test suite was executed as part of this change (no `ng test` / CI run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3c7837c8832396ebccc69c616d1e)