### PR TITLE
Add Playwright smoke tests and e2e configuration

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+
+const mockSymbols = [
+  { id: '1', symbol: 'EURUSD', name: 'EURUSD', market: 'FX' }
+];
+
+const mockCandles = [
+  {
+    date: '2024-02-08T12:00:00.000Z',
+    open: 1.08,
+    high: 1.1,
+    low: 1.07,
+    close: 1.09
+  },
+  {
+    date: '2024-02-08T13:00:00.000Z',
+    open: 1.09,
+    high: 1.11,
+    low: 1.08,
+    close: 1.1
+  }
+];
+
+const mockStrategies = [
+  {
+    runId: 'run-123',
+    name: 'Momentum Alpha',
+    winCount: 12,
+    lossCount: 8,
+    totalReturn: 1.23,
+    maxDrawdown: 0.12,
+    averageTrade: 0.05,
+    averageSL: 0.02,
+    averageTP: 0.08,
+    symbol: 'EUR/USD',
+    timeframe: 'M15',
+    comparedSymbol: 'USD/JPY',
+    startStrategy: '2024-01-01T00:00:00.000Z',
+    endStrategy: '2024-02-01T00:00:00.000Z',
+    rrMoyen: 1.5,
+    totalNetReturn: 0.98,
+    netWinCount: 9,
+    netLossCount: 4,
+    averageNetTrade: 0.03
+  }
+];
+
+test('historical-data loads and renders the chart', async ({ page }) => {
+  await page.route('**/api/finance/symbols', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockSymbols)
+    });
+  });
+
+  await page.route('**/api/finance/charts/candles/date-time**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockCandles)
+    });
+  });
+
+  await page.goto('/historical-data');
+
+  await expect(page.getByRole('heading', { name: 'Graphique des Bougies' })).toBeVisible();
+  await expect(page.locator('#candlestickChart')).toBeVisible();
+});
+
+test('screen-strategies lists strategies and navigates to details', async ({ page }) => {
+  await page.route('**/all-strategies', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockStrategies)
+    });
+  });
+
+  await page.goto('/screen-strategies');
+
+  await page.getByLabel('Sélectionnez un symbole :').selectOption('EUR/USD');
+
+  await expect(page.locator('table.strategy-table')).toBeVisible();
+
+  await page.getByRole('button', { name: 'GO' }).first().click();
+
+  await expect(page).toHaveURL(/\/strategy-detail\//);
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "e2e": "npx playwright test",
+    "e2e:ui": "npx playwright test --ui",
+    "e2e:report": "npx playwright show-report"
   },
   "private": true,
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000
+  },
+  use: {
+    baseURL: 'http://localhost:4200',
+    trace: 'on-first-retry'
+  },
+  webServer: {
+    command: 'npm run start -- --host 0.0.0.0 --port 4200',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  }
+});


### PR DESCRIPTION
### Motivation
- Add end-to-end smoke checks to catch regressions for the chart and strategy flows (`/historical-data` and `/screen-strategies`).
- Provide a minimal Playwright setup so developers can run e2e checks locally or wire them into CI later.
- Use route mocking in tests so the flows can be validated without a running backend.
- Expose convenient npm scripts to run Playwright (`e2e`, `e2e:ui`, `e2e:report`).

### Description
- Add `e2e/smoke.spec.ts` containing two smoke tests that mock API responses and verify chart rendering and strategy list/navigation.
- Add `playwright.config.ts` with `testDir`, timeouts, `baseURL` and a `webServer` block to start the Angular app for tests.
- Update `package.json` to add `e2e`, `e2e:ui` and `e2e:report` scripts that invoke Playwright.
- Tests mock endpoints `**/api/finance/symbols`, `**/api/finance/charts/candles/date-time**` and `**/all-strategies` to keep tests deterministic.

### Testing
- No automated tests were executed as part of this change, so there are no passing or failing test runs to report.
- Attempting to install Playwright with `npm install --save-dev @playwright/test` in this environment failed with a `403` from the npm registry, which prevented running the e2e suite here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3c7f5538832391456d0420fe5c4e)