### PR TITLE
Add error handling and fallback UI for HistoricalData and StatisticData components

### DIFF
--- a/src/app/components/historical-data/historical-data.component.html
+++ b/src/app/components/historical-data/historical-data.component.html
@@ -18,11 +18,13 @@
   <button (click)="loadData()">Charger</button>
 </div>
 
-<div *ngIf="candles.length > 0; else loading">
+<p *ngIf="errorMessage" class="error-message" role="alert">{{ errorMessage }}</p>
+
+<div *ngIf="!errorMessage && candles.length > 0; else loading">
   <h2>Graphique des Bougies</h2>
   <canvas id="candlestickChart"></canvas>
 </div>
 
 <ng-template #loading>
-  <p>Loading data...</p>
+  <p *ngIf="isLoading">Loading data...</p>
 </ng-template>

--- a/src/app/components/historical-data/historical-data.component.spec.ts
+++ b/src/app/components/historical-data/historical-data.component.spec.ts
@@ -1,14 +1,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
 
 import { HistoricalDataComponent } from './historical-data.component';
+import { TradingDataService } from '../../services/trading-data.service';
 
 describe('HistoricalDataComponent', () => {
   let component: HistoricalDataComponent;
   let fixture: ComponentFixture<HistoricalDataComponent>;
 
+  let tradingService: jasmine.SpyObj<TradingDataService>;
+
   beforeEach(async () => {
+    tradingService = jasmine.createSpyObj('TradingDataService', [
+      'getSymbols',
+      'getHistoricalCandlesTimeframeCME'
+    ]);
+    tradingService.getSymbols.and.returnValue(of([{ id: '1', symbol: 'EURUSD', name: 'Euro', market: 'FX' }]));
+    tradingService.getHistoricalCandlesTimeframeCME.and.returnValue(of([]));
+
     await TestBed.configureTestingModule({
-      imports: [HistoricalDataComponent]
+      imports: [HistoricalDataComponent],
+      providers: [{ provide: TradingDataService, useValue: tradingService }]
     })
     .compileComponents();
 
@@ -19,5 +32,39 @@ describe('HistoricalDataComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('shows a fallback message when symbol loading fails', () => {
+    tradingService.getSymbols.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' }))
+    );
+    const consoleSpy = spyOn(console, 'error');
+
+    fixture = TestBed.createComponent(HistoricalDataComponent);
+    component = fixture.componentInstance;
+    expect(() => fixture.detectChanges()).not.toThrow();
+
+    fixture.detectChanges();
+    const errorMessage = fixture.nativeElement.querySelector('.error-message');
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(errorMessage?.textContent).toContain('Impossible de charger les symboles');
+  });
+
+  it('shows a fallback message when historical data loading fails', () => {
+    tradingService.getSymbols.and.returnValue(of([{ id: '1', symbol: 'EURUSD', name: 'Euro', market: 'FX' }]));
+    tradingService.getHistoricalCandlesTimeframeCME.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 500, statusText: 'Server Error' }))
+    );
+    const consoleSpy = spyOn(console, 'error');
+
+    fixture = TestBed.createComponent(HistoricalDataComponent);
+    component = fixture.componentInstance;
+    expect(() => fixture.detectChanges()).not.toThrow();
+
+    fixture.detectChanges();
+    const errorMessage = fixture.nativeElement.querySelector('.error-message');
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(errorMessage?.textContent).toContain('Impossible de charger les données historiques');
+    expect(component.isLoading).toBeFalse();
   });
 });

--- a/src/app/components/historical-data/historical-data.component.ts
+++ b/src/app/components/historical-data/historical-data.component.ts
@@ -23,6 +23,8 @@ import { mapCandlesToOhlc } from '../candlestick-chart.utils';
 export class HistoricalDataComponent implements OnInit, AfterViewInit {
   chart: any;
   candles: any[] = [];
+  errorMessage: string | null = null;
+  isLoading = false;
   trades = [
     {
       entryDate: new Date('2024-02-08T14:15:00'),
@@ -65,13 +67,22 @@ export class HistoricalDataComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
-        this.tradingService.getSymbols().subscribe(list => {
+        this.isLoading = true;
+        this.errorMessage = null;
+        this.tradingService.getSymbols().subscribe({
+          next: (list) => {
             this.symbols = list ?? [];
-              if (!this.selectedSymbol && this.symbols.length) {
-                this.selectedSymbol = this.symbols[0].symbol;
-              }
-              this.loadData();
-          });
+            if (!this.selectedSymbol && this.symbols.length) {
+              this.selectedSymbol = this.symbols[0].symbol;
+            }
+            this.loadData();
+          },
+          error: (err) => {
+            console.error(err);
+            this.errorMessage = 'Impossible de charger les symboles.';
+            this.isLoading = false;
+          }
+        });
     }
 
 
@@ -92,20 +103,31 @@ export class HistoricalDataComponent implements OnInit, AfterViewInit {
   }
 
   loadData() {
-    this.tradingService.getHistoricalCandlesTimeframeCME(this.selectedSymbol, this.selectedTimeframe, this.startDate, this.endDate).subscribe(data => {
-      console.log('Données reçues loadData :', data);
-      this.candles = data;
-      //console.log("Données utilisées :", this.candles.map(c => new Date(c.date).toUTCString()));
-      //console.log("Données utilisées :", this.candles.map(c => new Date(c.date).toISOString()));
+    this.isLoading = true;
+    this.errorMessage = null;
+    this.tradingService.getHistoricalCandlesTimeframeCME(this.selectedSymbol, this.selectedTimeframe, this.startDate, this.endDate).subscribe({
+      next: (data) => {
+        console.log('Données reçues loadData :', data);
+        this.candles = data;
+        //console.log("Données utilisées :", this.candles.map(c => new Date(c.date).toUTCString()));
+        //console.log("Données utilisées :", this.candles.map(c => new Date(c.date).toISOString()));
 
-      /*
-      this.candles = this.candles.filter(c => {
-        const date = new Date(c.date);
-        const day = date.getUTCDay();
-        return day !== 0 && day !== 6; // ✅ Exclut samedi et dimanche
-      });*/
-      console.log('Données filtrées loadData :', this.candles);
-      setTimeout(() => this.createChart(), 0); // ✅ Attendre que le DOM soit prêt
+        /*
+        this.candles = this.candles.filter(c => {
+          const date = new Date(c.date);
+          const day = date.getUTCDay();
+          return day !== 0 && day !== 6; // ✅ Exclut samedi et dimanche
+        });*/
+        console.log('Données filtrées loadData :', this.candles);
+        this.isLoading = false;
+        setTimeout(() => this.createChart(), 0); // ✅ Attendre que le DOM soit prêt
+      },
+      error: (err) => {
+        console.error(err);
+        this.candles = [];
+        this.errorMessage = 'Impossible de charger les données historiques.';
+        this.isLoading = false;
+      }
     });
   }
   getAnnotations(): Record<string, LineAnnotationOptions> {
@@ -246,4 +268,3 @@ export class HistoricalDataComponent implements OnInit, AfterViewInit {
     });
   }
 }
-

--- a/src/app/components/statistic-data/statistic-data.component.html
+++ b/src/app/components/statistic-data/statistic-data.component.html
@@ -51,6 +51,7 @@
 
   <!-- Loader -->
   <div *ngIf="isLoading" class="loader">Chargement...</div>
+  <div *ngIf="errorMessage" class="error-message" role="alert">{{ errorMessage }}</div>
   <canvas id="statsChart"></canvas>
   <!-- Affichage des résultats -->
   <table *ngIf="statistics">

--- a/src/app/components/statistic-data/statistic-data.component.spec.ts
+++ b/src/app/components/statistic-data/statistic-data.component.spec.ts
@@ -1,20 +1,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { buildChartDatasets, StatisticDataComponent } from './statistic-data.component';
 
 describe('StatisticDataComponent', () => {
   let component: StatisticDataComponent;
   let fixture: ComponentFixture<StatisticDataComponent>;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [StatisticDataComponent]
+      imports: [HttpClientTestingModule, StatisticDataComponent]
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(StatisticDataComponent);
     component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should create', () => {
@@ -52,5 +59,24 @@ describe('StatisticDataComponent', () => {
     expect(result.datasets).toHaveSize(2);
     expect(result.datasets[0].data).toEqual([5, 0, 0]);
     expect(result.datasets[1].data).toEqual([2, 0, 0]);
+  });
+
+  it('shows a fallback message when the statistics request fails', () => {
+    const consoleSpy = spyOn(console, 'error');
+
+    component.selectedSymbol = 'EURUSD';
+    component.selectedAnalysis = 'bullish-bearish-all';
+
+    expect(() => component.loadStatistics()).not.toThrow();
+
+    const req = httpMock.expectOne('http://localhost:8090/filter/bullish-bearish-stats/all?symbol=EURUSD');
+    req.flush('Not Found', { status: 404, statusText: 'Not Found' });
+
+    fixture.detectChanges();
+    const errorMessage = fixture.nativeElement.querySelector('.error-message');
+
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(component.isLoading).toBeFalse();
+    expect(errorMessage?.textContent).toContain('Impossible de charger les statistiques');
   });
 });

--- a/src/app/components/statistic-data/statistic-data.component.ts
+++ b/src/app/components/statistic-data/statistic-data.component.ts
@@ -53,6 +53,7 @@ export class StatisticDataComponent {
   chart: Chart | undefined;
 
   isLoading = false;
+  errorMessage: string | null = null;
   statistics: any;
   rawResponse: any;
   statisticFields: string[] = [];
@@ -101,6 +102,7 @@ export class StatisticDataComponent {
 
   loadStatistics(): void {
     this.isLoading = true;
+    this.errorMessage = null;
     this.statistics = null;
     this.rawResponse = null;
 
@@ -210,6 +212,7 @@ export class StatisticDataComponent {
       },
       error: (err) => {
         console.error(err);
+        this.errorMessage = 'Impossible de charger les statistiques.';
         this.isLoading = false;
       }
     });


### PR DESCRIPTION
### Motivation
- Improve resilience of data-driven components when the backend returns HTTP errors (404/500). 
- Surface a clear fallback UI and avoid unhandled exceptions during symbol or statistics loading. 
- Make components show loading and error states so the user sees meaningful feedback instead of an empty chart area. 
- Provide automated tests that simulate HTTP failures to guard regressions. 

### Description
- Added `errorMessage` and `isLoading` state management to `HistoricalDataComponent` and `StatisticDataComponent`. 
- Updated templates to show a fallback message (element with `.error-message` and `role="alert"`) and a loading indicator conditional on `isLoading`. 
- Reworked HTTP subscriptions to use object form (`subscribe({ next, error })`) and set `errorMessage` when requests fail while clearing/setting `isLoading`. 
- Added unit tests that mock `TradingDataService` and `HttpClient` behavior to simulate `404`/`500` errors and assert that fallback UI appears and no exception is thrown (`historical-data.component.spec.ts`, `statistic-data.component.spec.ts`). 

### Testing
- Started the dev server with `npm start` (Angular build) and the build completed successfully. 
- Ran a Playwright script that loaded `/historical-data` and captured a screenshot showing the `.error-message` element, and the script completed successfully. 
- Added unit tests covering HTTP 404/500 scenarios for both components, but `ng test` was not executed in this rollout. 
- Console error logging is asserted in tests to ensure errors are handled and do not propagate as unhandled exceptions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3c80dff08323a5c9085e14ea413e)