### PR TITLE
Add fallback error/loading UI and error-case specs for HistoricalData and StatisticData

### DIFF
--- a/src/app/components/historical-data/historical-data.component.html
+++ b/src/app/components/historical-data/historical-data.component.html
@@ -18,11 +18,16 @@
   <button (click)="loadData()">Charger</button>
 </div>
 
-<div *ngIf="candles.length > 0; else loading">
-  <h2>Graphique des Bougies</h2>
-  <canvas id="candlestickChart"></canvas>
-</div>
+<div *ngIf="errorMessage" class="error">{{ errorMessage }}</div>
 
-<ng-template #loading>
-  <p>Loading data...</p>
-</ng-template>
+<div *ngIf="!errorMessage">
+  <div *ngIf="candles.length > 0; else loading">
+    <h2>Graphique des Bougies</h2>
+    <canvas id="candlestickChart"></canvas>
+  </div>
+
+  <ng-template #loading>
+    <p *ngIf="isLoading">Loading data...</p>
+    <p *ngIf="!isLoading">Aucune donnée disponible.</p>
+  </ng-template>
+</div>

--- a/src/app/components/historical-data/historical-data.component.spec.ts
+++ b/src/app/components/historical-data/historical-data.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
 
 import { HistoricalDataComponent } from './historical-data.component';
 import { TradingDataService } from '../../services/trading-data.service';
@@ -95,4 +96,21 @@ describe('HistoricalDataComponent', () => {
       c: updatedCandles[0].close
     }));
   }));
+
+  it('should show an error message when candles request fails', () => {
+    tradingServiceSpy.getSymbols.and.returnValue(of([
+      { id: '1', symbol: 'EURUSD', name: 'Euro Dollar', market: 'FX' }
+    ]));
+    tradingServiceSpy.getHistoricalCandlesTimeframeCME.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 500, statusText: 'Server Error' }))
+    );
+
+    fixture = TestBed.createComponent(HistoricalDataComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const errorMessage = fixture.nativeElement.querySelector('.error');
+    expect(component.errorMessage).toBe('Erreur lors du chargement des données.');
+    expect(errorMessage?.textContent).toContain('Erreur lors du chargement des données.');
+  });
 });

--- a/src/app/components/historical-data/historical-data.component.ts
+++ b/src/app/components/historical-data/historical-data.component.ts
@@ -53,6 +53,8 @@ export class HistoricalDataComponent implements OnInit, AfterViewInit {
 
   startDate: string = '';
   endDate: string = '';
+  isLoading = false;
+  errorMessage = '';
 
   // Symbol et timeframe sélectionnés
   selectedSymbol = '';
@@ -65,13 +67,21 @@ export class HistoricalDataComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
-        this.tradingService.getSymbols().subscribe(list => {
+        this.isLoading = true;
+        this.errorMessage = '';
+        this.tradingService.getSymbols().subscribe({
+          next: (list) => {
             this.symbols = list ?? [];
-              if (!this.selectedSymbol && this.symbols.length) {
-                this.selectedSymbol = this.symbols[0].symbol;
-              }
-              this.loadData();
-          });
+            if (!this.selectedSymbol && this.symbols.length) {
+              this.selectedSymbol = this.symbols[0].symbol;
+            }
+            this.loadData();
+          },
+          error: () => {
+            this.isLoading = false;
+            this.errorMessage = 'Erreur lors du chargement des symboles.';
+          }
+        });
     }
 
 
@@ -92,20 +102,30 @@ export class HistoricalDataComponent implements OnInit, AfterViewInit {
   }
 
   loadData() {
-    this.tradingService.getHistoricalCandlesTimeframeCME(this.selectedSymbol, this.selectedTimeframe, this.startDate, this.endDate).subscribe(data => {
-      console.log('Données reçues loadData :', data);
-      this.candles = data;
-      //console.log("Données utilisées :", this.candles.map(c => new Date(c.date).toUTCString()));
-      //console.log("Données utilisées :", this.candles.map(c => new Date(c.date).toISOString()));
+    this.isLoading = true;
+    this.errorMessage = '';
+    this.tradingService.getHistoricalCandlesTimeframeCME(this.selectedSymbol, this.selectedTimeframe, this.startDate, this.endDate).subscribe({
+      next: (data) => {
+        console.log('Données reçues loadData :', data);
+        this.candles = data;
+        //console.log("Données utilisées :", this.candles.map(c => new Date(c.date).toUTCString()));
+        //console.log("Données utilisées :", this.candles.map(c => new Date(c.date).toISOString()));
 
-      /*
-      this.candles = this.candles.filter(c => {
-        const date = new Date(c.date);
-        const day = date.getUTCDay();
-        return day !== 0 && day !== 6; // ✅ Exclut samedi et dimanche
-      });*/
-      console.log('Données filtrées loadData :', this.candles);
-      setTimeout(() => this.createChart(), 0); // ✅ Attendre que le DOM soit prêt
+        /*
+        this.candles = this.candles.filter(c => {
+          const date = new Date(c.date);
+          const day = date.getUTCDay();
+          return day !== 0 && day !== 6; // ✅ Exclut samedi et dimanche
+        });*/
+        console.log('Données filtrées loadData :', this.candles);
+        this.isLoading = false;
+        setTimeout(() => this.createChart(), 0); // ✅ Attendre que le DOM soit prêt
+      },
+      error: () => {
+        this.isLoading = false;
+        this.candles = [];
+        this.errorMessage = 'Erreur lors du chargement des données.';
+      }
     });
   }
   getAnnotations(): Record<string, LineAnnotationOptions> {
@@ -246,4 +266,3 @@ export class HistoricalDataComponent implements OnInit, AfterViewInit {
     });
   }
 }
-

--- a/src/app/components/statistic-data/statistic-data.component.html
+++ b/src/app/components/statistic-data/statistic-data.component.html
@@ -51,6 +51,7 @@
 
   <!-- Loader -->
   <div *ngIf="isLoading" class="loader">Chargement...</div>
+  <div *ngIf="errorMessage" class="error">{{ errorMessage }}</div>
   <canvas id="statsChart"></canvas>
   <!-- Affichage des résultats -->
   <table *ngIf="statistics">

--- a/src/app/components/statistic-data/statistic-data.component.spec.ts
+++ b/src/app/components/statistic-data/statistic-data.component.spec.ts
@@ -97,4 +97,25 @@ describe('StatisticDataComponent', () => {
     const rows = fixture.nativeElement.querySelectorAll('tbody tr');
     expect(rows.length).toBe(2);
   });
+
+  it('shows fallback message when statistics request fails', () => {
+    component.selectedAnalysis = 'bullish-bearish-multi';
+    component.selectedSymbol = 'EURUSD';
+    component.selectedTimeframes = ['1h'];
+
+    component.loadStatistics();
+
+    const req = httpMock.expectOne((request) =>
+      request.url === 'http://localhost:8090/filter/bullish-bearish-stats/multi-timeframes'
+      && request.params.get('symbol') === 'EURUSD'
+      && request.params.get('timeframes') === '1h'
+    );
+
+    req.flush('Not found', { status: 404, statusText: 'Not Found' });
+    fixture.detectChanges();
+
+    const errorMessage = fixture.nativeElement.querySelector('.error');
+    expect(component.errorMessage).toBe('Erreur lors du chargement des statistiques.');
+    expect(errorMessage?.textContent).toContain('Erreur lors du chargement des statistiques.');
+  });
 });

--- a/src/app/components/statistic-data/statistic-data.component.ts
+++ b/src/app/components/statistic-data/statistic-data.component.ts
@@ -53,6 +53,7 @@ export class StatisticDataComponent {
   chart: Chart | undefined;
 
   isLoading = false;
+  errorMessage = '';
   statistics: any;
   rawResponse: any;
   statisticFields: string[] = [];
@@ -101,6 +102,7 @@ export class StatisticDataComponent {
 
   loadStatistics(): void {
     this.isLoading = true;
+    this.errorMessage = '';
     this.statistics = null;
     this.rawResponse = null;
 
@@ -211,6 +213,8 @@ export class StatisticDataComponent {
       error: (err) => {
         console.error(err);
         this.isLoading = false;
+        this.statistics = null;
+        this.errorMessage = 'Erreur lors du chargement des statistiques.';
       }
     });
   }


### PR DESCRIPTION
### Motivation

- Improve resiliency of data components by handling HTTP failures and avoiding uncaught exceptions when backend calls return 500/404. 
- Provide clear fallback UI state (loading / no-data / error) so the app shows meaningful messages instead of failing silently.
- Target the `HistoricalDataComponent` and `StatisticDataComponent` to cover both charting flows (candlesticks and statistics).

### Description

- Add `isLoading` and `errorMessage` state properties and update subscriptions to use object-style `subscribe({ next, error })` handlers in `HistoricalDataComponent` and `StatisticDataComponent` to surface errors. 
- Update templates `historical-data.component.html` and `statistic-data.component.html` to render fallback UIs (loading text, "Aucune donnée disponible", and `.error` messages) based on `isLoading` and `errorMessage`.
- Ensure failed requests clear data (`this.candles = []` / `this.statistics = null`) and set user-friendly messages like `'Erreur lors du chargement des données.'` and `'Erreur lors du chargement des statistiques.'`.
- Add unit spec coverage that simulates HTTP errors using `throwError`/`HttpErrorResponse` and `HttpTestingController` to verify the UI state and `errorMessage` are set (`historical-data.component.spec.ts` and `statistic-data.component.spec.ts`).

### Testing

- Added/updated unit tests in `src/app/components/historical-data/historical-data.component.spec.ts` and `src/app/components/statistic-data/statistic-data.component.spec.ts` that simulate HTTP 500 and 404 error responses via `throwError` and `HttpTestingController` respectively.
- No automated tests were executed as part of this change (tests were added but not run in this environment).
- No runtime test results to report from this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d97fb276c8323b0f78ba947fb6033)