### PR TITLE
Add unit tests for ActiveRobotsComponent (filtering, toggle, LiveSignals integration)

### DIFF
--- a/src/app/components/active-robots/active-robots.component.spec.ts
+++ b/src/app/components/active-robots/active-robots.component.spec.ts
@@ -1,0 +1,82 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+
+import { ActiveRobotsComponent } from './active-robots.component';
+import { LiveSignalsService } from '../../services/live-signals.service';
+import { LiveSignal } from '../../models/live-signal.model';
+
+describe('ActiveRobotsComponent', () => {
+  let component: ActiveRobotsComponent;
+  let fixture: ComponentFixture<ActiveRobotsComponent>;
+  let liveSignalsService: jasmine.SpyObj<LiveSignalsService>;
+  let selectedSubject: BehaviorSubject<LiveSignal | null>;
+
+  beforeEach(async () => {
+    selectedSubject = new BehaviorSubject<LiveSignal | null>(null);
+    liveSignalsService = jasmine.createSpyObj<LiveSignalsService>('LiveSignalsService', ['connect', 'disconnect'], {
+      selected$: selectedSubject
+    });
+
+    const queryParamMapSubject = new BehaviorSubject(convertToParamMap({ broker: 'ibkr' }));
+
+    await TestBed.configureTestingModule({
+      imports: [ActiveRobotsComponent],
+      providers: [
+        { provide: LiveSignalsService, useValue: liveSignalsService },
+        { provide: ActivatedRoute, useValue: { queryParamMap: queryParamMapSubject.asObservable() } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ActiveRobotsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('filters markets and robots by broker and timeframe', () => {
+    component.brokerControl.setValue('IBKR');
+    component.timeframeControl.setValue('15m');
+
+    expect(component.filteredMarkets.length).toBeGreaterThan(0);
+    component.filteredMarkets.forEach(market => {
+      expect(market.broker).toBe('IBKR');
+      expect(market.timeframe).toBe('15m');
+    });
+
+    expect(component.filteredRobots.length).toBeGreaterThan(0);
+    component.filteredRobots.forEach(robot => {
+      expect(robot.broker).toBe('IBKR');
+      expect(robot.timeframes).toContain('15m');
+    });
+  });
+
+  it('toggles robot active state', () => {
+    const robot = component.robots[0];
+    const initialState = robot.active;
+
+    component.toggleRobot(robot);
+
+    expect(robot.active).toBe(!initialState);
+  });
+
+  it('updates selected signal from LiveSignalsService', () => {
+    const signal: LiveSignal = {
+      strategyId: 'signal-1',
+      symbol: 'EURUSD',
+      timeframe: '15m',
+      side: 'LONG',
+      entryPrice: 1.1,
+      tsOpenUtc: new Date().toISOString()
+    };
+
+    selectedSubject.next(signal);
+
+    expect(component.selectedSignal).toBe(signal);
+  });
+
+  it('disconnects from live signals on destroy', () => {
+    component.ngOnDestroy();
+
+    expect(liveSignalsService.disconnect).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Add unit tests to ensure `ActiveRobotsComponent` correctly filters robots/markets by broker and timeframe.
- Verify `toggleRobot()` flips the `active` state of a robot instance.
- Ensure the component reacts to `LiveSignalsService.selected$` updates and exposes `selectedSignal` correctly.
- Confirm component lifecycle cleans up by calling `disconnect()` on `ngOnDestroy()`.

### Description
- Added `src/app/components/active-robots/active-robots.component.spec.ts` with tests for filtering, toggling, live signal selection, and lifecycle teardown.
- Mocked `ActivatedRoute.queryParamMap` using a `BehaviorSubject` and `convertToParamMap` to simulate route query parameters.
- Mocked `LiveSignalsService` as a Jasmine spy object exposing a `selected$` `BehaviorSubject` and spies for `connect`/`disconnect` to validate interactions. 
- Updated test signal payload to match the `LiveSignal` interface (`strategyId`, `symbol`, `tsOpenUtc`, `entryPrice`, `side`).

### Testing
- Added unit test file `src/app/components/active-robots/active-robots.component.spec.ts` that uses `TestBed` and `BehaviorSubject`-backed mocks. 
- The tests exercise component initialization via `TestBed.createComponent` in `beforeEach` and cover the specified behaviors. 
- Automated test execution was not run as part of this change. 
- No CI results are included in this PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e51768dc83239e1924a42b6d7cdc)