### PR TITLE
Add unit tests for LiveSignalChartComponent lifecycle (init, update, destroy)

### DIFF
--- a/src/app/components/live-signal-chart/live-signal-chart.component.spec.ts
+++ b/src/app/components/live-signal-chart/live-signal-chart.component.spec.ts
@@ -1,0 +1,117 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SimpleChange } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import * as lightweightCharts from 'lightweight-charts';
+
+import { LiveSignalChartComponent } from './live-signal-chart.component';
+import { MarketDataService } from '../../services/market-data.service';
+import { LiveSignal } from '../../models/live-signal.model';
+
+class MockMarketDataService {
+  getWindow = jasmine.createSpy('getWindow');
+}
+
+describe('LiveSignalChartComponent', () => {
+  let component: LiveSignalChartComponent;
+  let fixture: ComponentFixture<LiveSignalChartComponent>;
+  let marketDataService: MockMarketDataService;
+  let seriesApi: { setData: jasmine.Spy; setMarkers: jasmine.Spy };
+  let chartApi: {
+    addCandlestickSeries: jasmine.Spy;
+    remove: jasmine.Spy;
+    timeScale: jasmine.Spy;
+  };
+
+  const buildSignal = (): LiveSignal => ({
+    strategyId: 'strat-1',
+    symbol: 'EURUSD',
+    timeframe: '1h',
+    tsOpenUtc: '2024-01-01T00:00:00Z',
+    side: 'LONG',
+    entryPrice: 1.2345,
+    payload: {
+      exitTsUtc: '2024-01-01T01:00:00Z'
+    }
+  });
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LiveSignalChartComponent],
+      providers: [{ provide: MarketDataService, useClass: MockMarketDataService }]
+    }).compileComponents();
+
+    seriesApi = {
+      setData: jasmine.createSpy('setData'),
+      setMarkers: jasmine.createSpy('setMarkers')
+    };
+
+    chartApi = {
+      addCandlestickSeries: jasmine.createSpy('addCandlestickSeries').and.returnValue(seriesApi),
+      remove: jasmine.createSpy('remove'),
+      timeScale: jasmine.createSpy('timeScale').and.returnValue({
+        fitContent: jasmine.createSpy('fitContent')
+      })
+    };
+
+    spyOn(lightweightCharts, 'createChart').and.returnValue(chartApi as never);
+
+    fixture = TestBed.createComponent(LiveSignalChartComponent);
+    component = fixture.componentInstance;
+    marketDataService = TestBed.inject(MarketDataService) as unknown as MockMarketDataService;
+  });
+
+  it('initializes the chart on ngAfterViewInit', () => {
+    marketDataService.getWindow.and.returnValue(of({ bars: [] }));
+    component.signal = buildSignal();
+
+    fixture.detectChanges();
+
+    expect(lightweightCharts.createChart).toHaveBeenCalled();
+    expect(chartApi.addCandlestickSeries).toHaveBeenCalled();
+  });
+
+  it('updates when signal input changes', () => {
+    marketDataService.getWindow.and.returnValue(
+      of({
+        bars: [
+          {
+            tsUtc: '2024-01-01T00:00:00Z',
+            open: 1,
+            high: 2,
+            low: 0.5,
+            close: 1.5
+          }
+        ]
+      })
+    );
+
+    fixture.detectChanges();
+
+    const nextSignal = buildSignal();
+    component.signal = nextSignal;
+    component.ngOnChanges({
+      signal: new SimpleChange(null, nextSignal, false)
+    });
+
+    expect(marketDataService.getWindow).toHaveBeenCalled();
+    expect(seriesApi.setData).toHaveBeenCalled();
+    expect(seriesApi.setMarkers).toHaveBeenCalled();
+  });
+
+  it('cleans up subscriptions and chart on destroy', () => {
+    let unsubscribed = false;
+    marketDataService.getWindow.and.returnValue(
+      new Observable(() => () => {
+        unsubscribed = true;
+      })
+    );
+    component.signal = buildSignal();
+
+    fixture.detectChanges();
+
+    component.ngOnDestroy();
+
+    expect(unsubscribed).toBeTrue();
+    expect(chartApi.remove).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Add unit tests to verify the chart is initialized in `ngAfterViewInit` to prevent regressions in rendering.
- Ensure the component updates series data and markers when the `signal` input changes via `ngOnChanges`.
- Verify cleanup of subscriptions and chart resources in `ngOnDestroy` to avoid memory leaks.

### Description
- Add `src/app/components/live-signal-chart/live-signal-chart.component.spec.ts` containing unit tests for lifecycle behavior.
- Mock `lightweight-charts` `createChart` to return a fake chart API with `addCandlestickSeries`, `remove`, and `timeScale().fitContent` spies.
- Provide a `MockMarketDataService` with a jasmine spy for `getWindow` to control emitted bar data. 
- Implement tests asserting initialization (`ngAfterViewInit`), input-driven updates (`ngOnChanges`), and teardown (`ngOnDestroy`).

### Testing
- Added Jasmine/Karma unit tests under the component spec file but did not run the test suite in this change. 
- The tests exercise the mocked `createChart`, `getWindow`, and series methods and are expected to pass when executed in the project test runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e51871cc83238bafb652b6cfd84c)