### PR TITLE
Add UI error handling to ScreenStrategies and extend unit tests

### DIFF
--- a/src/app/components/screen-strategies/screen-strategies.component.html
+++ b/src/app/components/screen-strategies/screen-strategies.component.html
@@ -8,6 +8,7 @@
 </div>
 
 <div *ngIf="isLoading">Chargement des stratégies...</div>
+<div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
 
 <<table *ngIf="strategies.length > 0" class="strategy-table">
   <thead>

--- a/src/app/components/screen-strategies/screen-strategies.component.spec.ts
+++ b/src/app/components/screen-strategies/screen-strategies.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { TradingDataService } from '../../services/trading-data.service';
 import { ScreenStrategiesComponent } from './screen-strategies.component';
@@ -51,5 +51,50 @@ describe('ScreenStrategiesComponent', () => {
       ['/strategy-detail', 'Breakout 1', 'run-123', 'EUR/USD', 'none'],
       { state: { strategy: component.strategies[0] } }
     );
+  });
+
+  it('renders the strategies table after loading strategies', () => {
+    tradingDataServiceSpy.getAllCalculatedStrategies.and.returnValue(of([
+      {
+        runId: 'run-456',
+        name: 'Backend Strategy',
+        symbol: 'EUR/USD',
+        winCount: 4,
+        lossCount: 1
+      }
+    ]));
+
+    component.selectedSymbol = 'EUR/USD';
+    component.loadStrategies();
+    fixture.detectChanges();
+
+    const rows = fixture.nativeElement.querySelectorAll('table.strategy-table tbody tr');
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('filters strategies by the selected symbol', () => {
+    component.selectedSymbol = 'NAS100';
+    component.loadStrategies();
+    fixture.detectChanges();
+
+    const symbolCells = Array.from(
+      fixture.nativeElement.querySelectorAll('table.strategy-table tbody tr td:nth-child(3)')
+    ).map((cell: Element) => cell.textContent?.trim());
+
+    expect(symbolCells.length).toBeGreaterThan(0);
+    expect(symbolCells.every(symbol => symbol === 'NAS100')).toBeTrue();
+  });
+
+  it('shows an error message when the service fails', () => {
+    tradingDataServiceSpy.getAllCalculatedStrategies.and.returnValue(
+      throwError(() => new Error('Service error'))
+    );
+
+    component.selectedSymbol = 'EUR/USD';
+    component.loadStrategies();
+    fixture.detectChanges();
+
+    const errorMessage = fixture.nativeElement.querySelector('.error-message');
+    expect(errorMessage?.textContent).toContain('Erreur lors du chargement des stratégies.');
   });
 });

--- a/src/app/components/screen-strategies/screen-strategies.component.ts
+++ b/src/app/components/screen-strategies/screen-strategies.component.ts
@@ -46,6 +46,7 @@ export class ScreenStrategiesComponent implements OnInit {
     averageNetTrade?: number
   }[] = [];
   isLoading: boolean = false;
+  errorMessage: string | null = null;
 
   constructor(private router: Router, private tradingService: TradingDataService
     // private strategyService: StrategyService (à injecter pour le backend)
@@ -73,6 +74,7 @@ export class ScreenStrategiesComponent implements OnInit {
     if (!this.selectedSymbol) return;
 
     this.isLoading = true;
+    this.errorMessage = null;
 
     const mockData = [
       {
@@ -141,14 +143,15 @@ export class ScreenStrategiesComponent implements OnInit {
 
         this.strategies = [...mockData, ...mapped];
         this.isLoading = false;
+        this.errorMessage = null;
         console.log(this.strategies);
       },
       error: (err) => {
         console.error('Erreur stratégie', err);
         this.strategies = [...mockData];
         this.isLoading = false;
+        this.errorMessage = 'Erreur lors du chargement des stratégies.';
       }
     });
   }
 }
-


### PR DESCRIPTION
### Motivation
- Provide visible UI feedback when strategy retrieval fails to improve user experience.
- Ensure the strategies table is rendered when backend data is available.
- Ensure strategies are filtered by the selected symbol before display.
- Add unit tests to cover rendering, filtering, and error handling behaviors.

### Description
- Add an `errorMessage: string | null` state to `ScreenStrategiesComponent` and reset it at the start of `loadStrategies`.
- Set `errorMessage` to a localized message on service error and clear it on successful load inside `loadStrategies`.
- Render the error message in the template via `<div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>`.
- Extend `src/app/components/screen-strategies/screen-strategies.component.spec.ts` with tests that assert table rendering after load, filtering by symbol, and UI error messaging when the service fails.

### Testing
- Added unit tests in `src/app/components/screen-strategies/screen-strategies.component.spec.ts` covering table rendering, symbol filtering, and service error UI messaging.
- No automated test run (CI or local `ng test`) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e51a729883238b182b5ad79d172d)