### PR TITLE
test: add specs for strategy-detail empty state and trade-loading error

### DIFF
--- a/src/app/components/strategy-detail/strategy-detail.component.spec.ts
+++ b/src/app/components/strategy-detail/strategy-detail.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { TradingDataService } from '../../services/trading-data.service';
 import { StrategyDetailComponent } from './strategy-detail.component';
@@ -79,5 +79,35 @@ describe('StrategyDetailComponent', () => {
         comparedSymbol: 'GBP/USD'
       })
     );
+  });
+
+  it('uses fallback strategy data when no strategy is found', () => {
+    const router = TestBed.inject(Router);
+    spyOn(router, 'getCurrentNavigation').and.returnValue(null as never);
+    tradingDataServiceSpy.getAllCalculatedStrategies.and.returnValue(of([]));
+
+    component.loadStrategy();
+
+    expect(component.strategy).toEqual({
+      name: 'Breakout 1',
+      symbol: 'EUR/USD',
+      comparedSymbol: 'GBP/USD'
+    });
+    expect(component.trades.length).toBe(0);
+  });
+
+  it('falls back to mock trades when trades loading fails', () => {
+    const router = TestBed.inject(Router);
+    spyOn(router, 'getCurrentNavigation').and.returnValue(null as never);
+    tradingDataServiceSpy.getTradesByStrategyName.and.returnValue(
+      throwError(() => new Error('Service failure'))
+    );
+    const mockTradesSpy = spyOn(component, 'getMockTrades').and.callThrough();
+
+    component.loadStrategy();
+
+    expect(mockTradesSpy).toHaveBeenCalled();
+    expect(component.trades.length).toBe(3);
+    expect(component.trades[0].id).toBe(1);
   });
 });


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for `StrategyDetailComponent` to handle edge cases when no backend strategy is found and when trades loading fails.
- Ensure the component falls back to sensible defaults and mock data instead of breaking the UI.

### Description
- Updated `src/app/components/strategy-detail/strategy-detail.component.spec.ts` and added `throwError` to the imports.
- Added a test that verifies the fallback strategy object is used when `getAllCalculatedStrategies` returns an empty array.
- Added a test that forces `getTradesByStrategyName` to throw and asserts the component calls `getMockTrades` and populates `trades` with the mock data.
- Tests use a spy on `router.getCurrentNavigation` and mocked `TradingDataService` responses to exercise the error and empty-state branches.

### Testing
- No automated tests were executed as part of this change (unit tests were added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e51b2afc8323a43f81873dbca100)