### PR TITLE
Add unit tests for candlestick chart utils

### DIFF
--- a/src/app/components/candlestick-chart.utils.spec.ts
+++ b/src/app/components/candlestick-chart.utils.spec.ts
@@ -1,0 +1,95 @@
+import { mapCandlesToOhlc } from './candlestick-chart.utils';
+
+describe('candlestick-chart utils', () => {
+  describe('mapCandlesToOhlc', () => {
+    it('handles null/undefined dates without throwing and maps safely', () => {
+      const candles = [
+        {
+          date: undefined as unknown as string,
+          open: 1,
+          high: 2,
+          low: 0.5,
+          close: 1.5
+        },
+        {
+          date: null as unknown as string,
+          open: 2,
+          high: 3,
+          low: 1.5,
+          close: 2.5
+        },
+        {
+          date: '2024-01-01T00:00:00Z',
+          open: 3,
+          high: 4,
+          low: 2.5,
+          close: 3.5
+        }
+      ];
+
+      const result = mapCandlesToOhlc(candles);
+
+      expect(result.length).toBe(2);
+      expect(result[0].x).toBe(0);
+      expect(result[1].x).toBe(new Date('2024-01-01T00:00:00Z').getTime());
+    });
+
+    it('preserves timestamp order from the input array', () => {
+      const candles = [
+        {
+          date: '2024-01-02T00:00:00Z',
+          open: 1,
+          high: 2,
+          low: 0.5,
+          close: 1.5
+        },
+        {
+          date: '2024-01-01T00:00:00Z',
+          open: 2,
+          high: 3,
+          low: 1.5,
+          close: 2.5
+        }
+      ];
+
+      const result = mapCandlesToOhlc(candles);
+
+      expect(result.map((point) => point.x)).toEqual([
+        new Date('2024-01-02T00:00:00Z').getTime(),
+        new Date('2024-01-01T00:00:00Z').getTime()
+      ]);
+    });
+
+    it('ignores invalid dates while handling volume data gracefully', () => {
+      const candles = [
+        {
+          date: 'invalid-date',
+          open: 1,
+          high: 2,
+          low: 0.5,
+          close: 1.5,
+          volume: 1000
+        } as unknown as { date: string; open: number; high: number; low: number; close: number },
+        {
+          date: '2024-01-03T00:00:00Z',
+          open: 2,
+          high: 3,
+          low: 1.5,
+          close: 2.5,
+          volume: 2000
+        } as unknown as { date: string; open: number; high: number; low: number; close: number }
+      ];
+
+      const result = mapCandlesToOhlc(candles);
+
+      expect(result.length).toBe(1);
+      expect(result[0]).toEqual({
+        x: new Date('2024-01-03T00:00:00Z').getTime(),
+        o: 2,
+        h: 3,
+        l: 1.5,
+        c: 2.5
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Add unit tests to harden `mapCandlesToOhlc` against null/undefined/invalid dates and unexpected input shapes.
- Ensure timestamp ordering behavior from input arrays is preserved by the mapping function.
- Verify that additional fields (like `volume`) do not break mapping and that invalid dates are ignored.

### Description
- Add `src/app/components/candlestick-chart.utils.spec.ts` containing tests for `mapCandlesToOhlc` covering null/undefined date handling, timestamp order preservation, and invalid-date/volume edge cases.
- Tests assert the mapped output shape (`x`, `o`, `h`, `l`, `c`) and the filtering of invalid timestamps.

### Testing
- No automated test suite was executed as part of this change (tests were added but not run).
- The new spec file was committed to the repository for CI/local execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e51c13108323bcad7dbd57ee25ea)