### PR TITLE
Add Playwright e2e for Active Robots filters and tables

### DIFF
--- a/e2e/active-robots.spec.ts
+++ b/e2e/active-robots.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+test('active robots filters update market and robot tables', async ({ page }) => {
+  await page.addInitScript(() => {
+    class MockEventSource {
+      readonly url: string;
+      readyState = 1;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(url: string) {
+        this.url = url;
+      }
+
+      close(): void {
+        this.readyState = 2;
+      }
+    }
+
+    // @ts-expect-error - override EventSource for test stability
+    window.EventSource = MockEventSource;
+  });
+
+  await page.goto('/active-robots');
+
+  const marketsRows = page.locator('.markets-panel tbody tr');
+  const robotsRows = page.locator('.robots-panel tbody tr');
+
+  await expect(page.getByRole('heading', { name: 'Robots actifs' })).toBeVisible();
+  await expect(page.locator('.markets-panel table')).toBeVisible();
+  await expect(page.locator('.robots-panel table')).toBeVisible();
+
+  await expect(marketsRows).toHaveCount(7);
+  await expect(robotsRows).toHaveCount(7);
+
+  await page.getByLabel('Broker').selectOption('IBKR');
+  await page.getByLabel('Timeframe').selectOption('1h');
+
+  await expect(marketsRows).toHaveCount(1);
+  await expect(robotsRows).toHaveCount(1);
+  await expect(marketsRows.first()).toContainText('GBPUSD');
+  await expect(robotsRows.first()).toContainText('London Breakout');
+
+  await page.getByLabel('Timeframe').selectOption('30m');
+
+  await expect(page.locator('.markets-panel td.empty')).toHaveText('Aucun marché ne correspond à ces filtres.');
+  await expect(page.locator('.robots-panel td.empty')).toHaveText('Aucun robot ne correspond à ces filtres.');
+});


### PR DESCRIPTION
### Motivation
- Add end-to-end coverage for the Active Robots page to ensure broker/timeframe filters drive the market and robot tables correctly.
- Verify table visibility and empty-state messaging when filters exclude all rows.
- Stabilize the E2E by preventing real server-sent events from interfering with the test run.

### Description
- Add `e2e/active-robots.spec.ts` which contains a Playwright spec that navigates to `/active-robots` and exercises the UI filters. 
- The spec injects a test `EventSource` mock to replace `window.EventSource` for deterministic behavior. 
- The test asserts initial row counts, interacts with `Broker` and `Timeframe` selects, and verifies filtered results and empty-state messages.

### Testing
- No automated test runs were executed as part of this change (the Playwright spec was added but not executed). 
- The spec targets UI behaviors: element visibility, row counts, selection changes, and empty-state text checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e521d5b8832396b6482e777ce3f3)