### PR TITLE
Add Playwright e2e test for live-data (IBKR start/stop + chart)

### DIFF
--- a/e2e/live-data.spec.ts
+++ b/e2e/live-data.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+
+const mockBars = [
+  {
+    tsMillis: 1710000000000,
+    open: 1.08,
+    high: 1.1,
+    low: 1.07,
+    close: 1.09
+  },
+  {
+    tsMillis: 1710000060000,
+    open: 1.09,
+    high: 1.11,
+    low: 1.08,
+    close: 1.1
+  }
+];
+
+test('live-data starts and stops IBKR stream with chart display', async ({ page }) => {
+  await page.route('**/ibkr/connect/wait', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ connected: true })
+    });
+  });
+
+  await page.route('**/ibkr/live/bars/start**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ reqId: 42 })
+    });
+  });
+
+  await page.route('**/ibkr/live/bars/42', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockBars)
+    });
+  });
+
+  await page.route('**/ibkr/live/bars/stop/42', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ stopped: true })
+    });
+  });
+
+  await page.route('**/trades**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([])
+    });
+  });
+
+  await page.route('**/portfolio', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([])
+    });
+  });
+
+  await page.goto('/live-data');
+
+  const connectButton = page.getByRole('button', { name: 'Connect & Wait' }).first();
+  const startButton = page.getByRole('button', { name: 'Start Live Bars' }).first();
+  const stopButton = page.getByRole('button', { name: 'Stop Live Bars' }).first();
+
+  await expect(connectButton).toBeVisible();
+  await expect(startButton).toBeDisabled();
+
+  await connectButton.click();
+  await expect(startButton).toBeEnabled();
+
+  await startButton.click();
+
+  await expect(page.locator('canvas').first()).toBeVisible();
+  await expect(page.getByText('Current reqId: 42').first()).toBeVisible();
+  await expect(stopButton).toBeEnabled();
+
+  await stopButton.click();
+
+  await expect(page.getByText('Current reqId: 42')).toHaveCount(0);
+  await expect(stopButton).toBeDisabled();
+});


### PR DESCRIPTION
### Motivation
- Add end-to-end coverage for the `live-data` UI flows around IBKR connect/start/stop and chart rendering.
- Ensure live streaming interactions and chart updates behave correctly and prevent regressions.
- Use mocked backend endpoints to make the test deterministic and avoid external dependencies.

### Description
- Add `e2e/live-data.spec.ts` Playwright spec that mocks IBKR and summary endpoints and exercises the live-data page.
- Mocked endpoints include `POST /ibkr/connect/wait`, `POST /ibkr/live/bars/start`, `GET /ibkr/live/bars/42`, `POST /ibkr/live/bars/stop/42`, `GET /trades`, and `GET /portfolio`.
- The test asserts the `Connect & Wait`, `Start Live Bars`, and `Stop Live Bars` button states and verifies the chart canvas visibility and `Current reqId` display.
- Only a test file was added; no application source files were modified.

### Testing
- The Playwright spec `e2e/live-data.spec.ts` was added and committed to the repository.
- No automated test runs were executed as part of this change (the spec was not run in CI during this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e523977c83239addfeba2932b041)